### PR TITLE
Handle color mode for white bulbs

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -218,6 +218,8 @@ class WyzeLight(LightEntity):
 
     @property
     def color_mode(self):
+        if self._bulb.type is DeviceTypes.LIGHT:
+            return ColorMode.COLOR_TEMP
         return ColorMode.COLOR_TEMP if self._bulb.color_mode == "2" else ColorMode.HS
 
     @property


### PR DESCRIPTION
Guard against older white bulbs not having a color mode property causing setup to fail.

Should fix https://github.com/SecKatie/ha-wyzeapi/issues/504

I don't have any of these bulbs so this is untested.