### PR TITLE
Update device names

### DIFF
--- a/custom_components/wyzeapi/climate.py
+++ b/custom_components/wyzeapi/climate.py
@@ -266,7 +266,7 @@ class WyzeThermostat(ClimateEntity):
             "identifiers": {
                 (DOMAIN, self._thermostat.mac)
             },
-            "name": self.name,
+            "name": self._thermostat.nickname,
             "manufacturer": "WyzeLabs",
             "model": self._thermostat.product_model
         }

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -102,7 +102,7 @@ class WyzeLight(LightEntity):
             "identifiers": {
                 (DOMAIN, self._bulb.mac)
             },
-            "name": self.name,
+            "name": self._bulb.nickname,
             "manufacturer": "WyzeLabs",
             "model": self._bulb.product_model
         }

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -420,7 +420,7 @@ class WyzeCamerafloodlight(LightEntity):
             "identifiers": {
                 (DOMAIN, self._device.mac)
             },
-            "name": self.name,
+            "name": self._device.nickname,
             "manufacturer": "WyzeLabs",
             "model": self._device.product_model
         }

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -110,7 +110,6 @@ class WyzeLight(LightEntity):
                     self._bulb.mac,
                 )
             },
-            "name": self.name,
             "manufacturer": "WyzeLabs",
             "model": self._bulb.product_model
         }

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -67,7 +67,7 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
             "identifiers": {
                 (DOMAIN, self._lock.mac)
             },
-            "name": self.name,
+            "name": self._lock.nickname,
             "manufacturer": "WyzeLabs",
             "model": self._lock.product_model
         }


### PR DESCRIPTION
Use device name instead of entity name in device info.

Prevents occasional naming of devices to (Device Name) Floodlight, etc