### PR TITLE
Update how switches write their state

### DIFF
--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -419,14 +419,14 @@ class WyzeCameraMotionSwitch(SwitchEntity):
         await self._service.turn_on_motion_detection(self._device)
 
         self._device.motion = True
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await self._service.turn_off_motion_detection(self._device)
 
         self._device.motion = False
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def name(self):

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -343,14 +343,14 @@ class WyzeCameraNotificationSwitch(SwitchEntity):
         await self._service.turn_on_notifications(self._device)
 
         self._device.notify = True
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await self._service.turn_off_notifications(self._device)
 
         self._device.notify = False
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def name(self):


### PR DESCRIPTION
Write the new state to the state machine when a switch is toggled. 

Should correct the toggling of switches reported in https://github.com/SecKatie/ha-wyzeapi/issues/546

