### PR TITLE
Remove unneeded attributes

### DIFF
--- a/custom_components/wyzeapi/alarm_control_panel.py
+++ b/custom_components/wyzeapi/alarm_control_panel.py
@@ -128,8 +128,6 @@ class WyzeHomeMonitoring(AlarmControlPanelEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.state,
-            "available": self.AVAILABLE,
             "device model": self.DEVICE_MODEL,
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/binary_sensor.py
+++ b/custom_components/wyzeapi/binary_sensor.py
@@ -115,8 +115,6 @@ class WyzeSensor(BinarySensorEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": self._sensor.product_model,
             "mac": self.unique_id
         }
@@ -182,8 +180,6 @@ class WyzeCameraMotion(BinarySensorEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": self._camera.product_model,
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/climate.py
+++ b/custom_components/wyzeapi/climate.py
@@ -294,8 +294,6 @@ class WyzeThermostat(ClimateEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.state,
-            "available": self.available,
             "device_model": self._thermostat.product_model,
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -241,8 +241,6 @@ class WyzeLight(LightEntity):
         """Return device attributes of the entity."""
         dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device_model": self._bulb.product_model,
             "mac": self.unique_id
         }
@@ -408,8 +406,6 @@ class WyzeCamerafloodlight(LightEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": f"{self._device.product_model}.floodlight",
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -120,8 +120,6 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
         """Return device attributes of the entity."""
         dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.state,
-            "available": self.available,
             "door_open": self._lock.door_open,
             "device_model": self._lock.product_model,
             "mac": self.unique_id

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -68,7 +68,7 @@ class WyzeLockBatterySensor(SensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
 
-    
+
 
     def __init__(self, lock, battery_type):
         self._enabled = None
@@ -142,7 +142,6 @@ class WyzeLockBatterySensor(SensorEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "available": self.available,
             "device model": f"{self._lock.product_model}.{self._battery_type}",
         }
 
@@ -208,7 +207,6 @@ class WyzeCameraBatterySensor(SensorEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "available": self.available,
             "device model": f"{self._camera.product_model}.battery",
         }
 

--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -105,8 +105,6 @@ class WyzeCameraSiren(SirenEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": f"{self._device.product_model}.siren",
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -141,8 +141,6 @@ class WyzeNotifications(SwitchEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "mac": self.unique_id
         }
 
@@ -235,8 +233,6 @@ class WyzeSwitch(SwitchEntity):
         """Return device attributes of the entity."""
         dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": self._device.product_model,
             "mac": self.unique_id
         }


### PR DESCRIPTION
Discussed in https://github.com/SecKatie/ha-wyzeapi/issues/373 a long time ago, State and Available as extra attributes is redundant and not needed. 

This may be a breaking change if anyone was using those attrs in an automation, but HA already provides this info natively. 

Will revisit device model and MAC later on, device model is already shown on the device page, MAC can be but currently isn't.  