### PR TITLE
Attribute cleanup part 2

### DIFF
--- a/custom_components/wyzeapi/alarm_control_panel.py
+++ b/custom_components/wyzeapi/alarm_control_panel.py
@@ -128,8 +128,6 @@ class WyzeHomeMonitoring(AlarmControlPanelEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.state,
-            "available": self.AVAILABLE,
             "device model": self.DEVICE_MODEL,
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/binary_sensor.py
+++ b/custom_components/wyzeapi/binary_sensor.py
@@ -115,8 +115,6 @@ class WyzeSensor(BinarySensorEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": self._sensor.product_model,
             "mac": self.unique_id
         }
@@ -182,8 +180,6 @@ class WyzeCameraMotion(BinarySensorEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": self._camera.product_model,
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/climate.py
+++ b/custom_components/wyzeapi/climate.py
@@ -294,8 +294,6 @@ class WyzeThermostat(ClimateEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.state,
-            "available": self.available,
             "device_model": self._thermostat.product_model,
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/climate.py
+++ b/custom_components/wyzeapi/climate.py
@@ -20,6 +20,7 @@ from homeassistant.components.climate.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from wyzeapy import Wyzeapy, ThermostatService
 from wyzeapy.services.thermostat_service import Thermostat, TemperatureUnit, HVACMode, Preset, FanMode, HVACState
 from .token_manager import token_exception_handler
@@ -266,6 +267,12 @@ class WyzeThermostat(ClimateEntity):
             "identifiers": {
                 (DOMAIN, self._thermostat.mac)
             },
+            "connections": {
+                (
+                    dr.CONNECTION_NETWORK_MAC,
+                    self._thermostat.mac,
+                )
+            },
             "name": self.name,
             "manufacturer": "WyzeLabs",
             "model": self._thermostat.product_model
@@ -288,15 +295,6 @@ class WyzeThermostat(ClimateEntity):
     def available(self) -> bool:
         """Return the connection status of this light"""
         return self._thermostat.available
-
-    @property
-    def extra_state_attributes(self):
-        """Return device attributes of the entity."""
-        return {
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-            "device_model": self._thermostat.product_model,
-            "mac": self.unique_id
-        }
 
     @token_exception_handler
     async def async_update(self) -> None:

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -20,6 +20,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from wyzeapy import Wyzeapy, BulbService, CameraService
 from wyzeapy.services.bulb_service import Bulb
 from wyzeapy.types import DeviceTypes, PropertyIDs
@@ -101,6 +102,12 @@ class WyzeLight(LightEntity):
         return {
             "identifiers": {
                 (DOMAIN, self._bulb.mac)
+            },
+            "connections": {
+                (
+                    dr.CONNECTION_NETWORK_MAC,
+                    self._bulb.mac,
+                )
             },
             "name": self.name,
             "manufacturer": "WyzeLabs",
@@ -239,11 +246,7 @@ class WyzeLight(LightEntity):
     @property
     def extra_state_attributes(self):
         """Return device attributes of the entity."""
-        dev_info = {
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-            "device_model": self._bulb.product_model,
-            "mac": self.unique_id
-        }
+        dev_info = {}
 
         # noinspection DuplicatedCode
         if self._bulb.device_params.get("ip"):
@@ -402,19 +405,16 @@ class WyzeCamerafloodlight(LightEntity):
         return f"{self._device.mac}-floodlight"
 
     @property
-    def extra_state_attributes(self):
-        """Return device attributes of the entity."""
-        return {
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-            "device model": f"{self._device.product_model}.floodlight",
-            "mac": self.unique_id
-        }
-
-    @property
     def device_info(self):
         return {
             "identifiers": {
                 (DOMAIN, self._device.mac)
+            },
+            "connections": {
+                (
+                    dr.CONNECTION_NETWORK_MAC,
+                    self._device.mac,
+                )
             },
             "name": self.name,
             "manufacturer": "WyzeLabs",

--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -241,8 +241,6 @@ class WyzeLight(LightEntity):
         """Return device attributes of the entity."""
         dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device_model": self._bulb.product_model,
             "mac": self.unique_id
         }
@@ -408,8 +406,6 @@ class WyzeCamerafloodlight(LightEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": f"{self._device.product_model}.floodlight",
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_CLIENT, DOMAIN, LOCK_UPDATED
 from .token_manager import token_exception_handler
@@ -66,6 +67,12 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
         return {
             "identifiers": {
                 (DOMAIN, self._lock.mac)
+            },
+            "connections": {
+                (
+                    dr.CONNECTION_NETWORK_MAC,
+                    self._lock.mac,
+                )
             },
             "name": self.name,
             "manufacturer": "WyzeLabs",
@@ -121,8 +128,6 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
         dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
             "door_open": self._lock.door_open,
-            "device_model": self._lock.product_model,
-            "mac": self.unique_id
         }
 
         # Add the lock battery value if it exists

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -120,8 +120,6 @@ class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
         """Return device attributes of the entity."""
         dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.state,
-            "available": self.available,
             "door_open": self._lock.door_open,
             "device_model": self._lock.product_model,
             "mac": self.unique_id

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, PERCENTAGE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_CLIENT, DOMAIN, LOCK_UPDATED, CAMERA_UPDATED
 from .token_manager import token_exception_handler
@@ -134,6 +135,12 @@ class WyzeLockBatterySensor(SensorEntity):
             "identifiers": {
                 (DOMAIN, self._lock.mac)
             },
+            "connections": {
+                (
+                    dr.CONNECTION_NETWORK_MAC,
+                    self._lock.mac,
+                )
+            },
             "name": f"{self._lock.nickname}.{self._battery_type}"
         }
 
@@ -198,6 +205,12 @@ class WyzeCameraBatterySensor(SensorEntity):
         return {
             "identifiers": {
                 (DOMAIN, self._camera.mac)
+            },
+            "connections": {
+                (
+                    dr.CONNECTION_NETWORK_MAC,
+                    self._camera.mac,
+                )
             },
             "name": f"{self._camera.nickname}.battery"
         }

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -68,7 +68,7 @@ class WyzeLockBatterySensor(SensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
 
-    
+
 
     def __init__(self, lock, battery_type):
         self._enabled = None
@@ -142,7 +142,6 @@ class WyzeLockBatterySensor(SensorEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "available": self.available,
             "device model": f"{self._lock.product_model}.{self._battery_type}",
         }
 
@@ -208,7 +207,6 @@ class WyzeCameraBatterySensor(SensorEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "available": self.available,
             "device model": f"{self._camera.product_model}.battery",
         }
 

--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -105,8 +105,6 @@ class WyzeCameraSiren(SirenEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": f"{self._device.product_model}.siren",
             "mac": self.unique_id
         }

--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -101,15 +101,6 @@ class WyzeCameraSiren(SirenEntity):
         return f"{self._device.mac}-siren"
 
     @property
-    def extra_state_attributes(self):
-        """Return device attributes of the entity."""
-        return {
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-            "device model": f"{self._device.product_model}.siren",
-            "mac": self.unique_id
-        }
-
-    @property
     def device_info(self):
         return {
             "identifiers": {

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -11,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
+from homeassistant.helpers import device_registry as dr
 from wyzeapy import CameraService, SwitchService, WallSwitchService, Wyzeapy, BulbService
 from wyzeapy.services.camera_service import Camera
 from wyzeapy.services.switch_service import Switch
@@ -136,14 +137,6 @@ class WyzeNotifications(SwitchEntity):
     def unique_id(self):
         return self._uid
 
-    @property
-    def extra_state_attributes(self):
-        """Return device attributes of the entity."""
-        return {
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-            "mac": self.unique_id
-        }
-
     async def async_update(self):
         if not self._just_updated:
             self._is_on = await self._client.notifications_are_on
@@ -180,6 +173,12 @@ class WyzeSwitch(SwitchEntity):
         return {
             "identifiers": {
                 (DOMAIN, self._device.mac)
+            },
+            "connections": {
+                (
+                    dr.CONNECTION_NETWORK_MAC,
+                    self._device.mac,
+                )
             },
             "name": self._device.nickname,
             "manufacturer": "WyzeLabs",
@@ -231,11 +230,7 @@ class WyzeSwitch(SwitchEntity):
     @property
     def extra_state_attributes(self):
         """Return device attributes of the entity."""
-        dev_info = {
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-            "device model": self._device.product_model,
-            "mac": self.unique_id
-        }
+        dev_info = {}
 
         if self._device.device_params.get("electricity"):
             dev_info["Battery"] = str(self._device.device_params.get("electricity") + "%")

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -141,8 +141,6 @@ class WyzeNotifications(SwitchEntity):
         """Return device attributes of the entity."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "mac": self.unique_id
         }
 
@@ -235,8 +233,6 @@ class WyzeSwitch(SwitchEntity):
         """Return device attributes of the entity."""
         dev_info = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "state": self.is_on,
-            "available": self.available,
             "device model": self._device.product_model,
             "mac": self.unique_id
         }


### PR DESCRIPTION
Part two of attribute cleanup. This PR contains all of the changes from the first plus adds MAC info to the devices and removes it from attributes, as well as model number, which is also shown on device page.  Keeping these separate PR's for now but I can close the first if we decide all the changes are acceptable. 