### PR TITLE
Add supported color modes property to floodlight

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -447,4 +447,10 @@ class WyzeCamerafloodlight(LightEntity):
 
     @property
     def color_mode(self):
+        """Return the color mode."""
+        return ColorMode.ONOFF
+
+    @property
+    def supported_color_modes(self):
+        """Return the supported color mode."""
         return ColorMode.ONOFF


### PR DESCRIPTION
Referencing https://developers.home-assistant.io/blog/2024/02/12/light-color-mode-mandatory/, add supported color mode property to the floodlight. Prevents the warning being thrown starting in HA 2024.3