### PR TITLE
Update sensor file

### DIFF
--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     UnitOfEnergy,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
 )
@@ -426,6 +427,7 @@ class WyzePlugDailyEnergySensor(RestoreSensor):
             "name": self._switch.nickname,
         }
 
+    @callback
     def _update_daily_sensor(self, event):
         """Update the sensor when the total sensor updates."""
         event_data = event.data


### PR DESCRIPTION
Must have missed this one when adding the power sensor:
https://github.com/SecKatie/ha-wyzeapi/issues/594

Also decorate the power daily sensor update method as a callback. It needs to run in the event loop since it was called from `async_track_state_change_event`.  New error starting in 2024.5:

`RuntimeError: Detected that custom integration 'wyzeapi' calls async_write_ha_state from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt. For more information, see https://developers.home-assistant.io/docs/asyncio_thread_safety/#async_write_ha_state at custom_components/wyzeapi/sensor.py, line 440: self.async_write_ha_state(). Please report it to the author of the 'wyzeapi' custom integration.`