### PR TITLE
Fixed and added entity toggles

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -62,9 +62,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 
 
     for camera in await camera_service.get_cameras():
-        # Only model that I know of that has a floodlight
-        if camera.product_model == "WYZE_CAKP2JFUS" or camera.product_model == "HL_CFL2":
-            lights.append(WyzeCamerafloodlight(camera, camera_service))
+        if (
+            (camera.product_model == "WYZE_CAKP2JFUS" and camera.device_params['dongle_product_model'] == "HL_CFL") or # Cam v3 with floodlight accessory
+            (camera.product_model == "LD_CFP") or # Floodlight Pro
+            (camera.product_model == "HL_CFL2") # Floodlight v2
+            ):
+            lights.append(WyzeCamerafloodlight(camera, camera_service, "floodlight"))
+        
+        elif ((camera.product_model == "WYZE_CAKP2JFUS" or camera.product_model == "HL_CAM4") and camera.device_params['dongle_product_model'] == "HL_CAM3SS"): # Cam v3 with lamp socket accessory
+            lights.append(WyzeCamerafloodlight(camera, camera_service, "lampsocket"))
+        
+        elif (camera.product_model == "AN_RSCW"): # Battery cam pro (integrated spotlight)
+            lights.append(WyzeCamerafloodlight(camera, camera_service, "spotlight"))
 
     async_add_entities(lights, True)
 
@@ -363,17 +372,17 @@ class WyzeCamerafloodlight(LightEntity):
     _available: bool
     _just_updated = False
 
-    def __init__(self, camera: Camera, camera_service: CameraService) -> None:
+    def __init__(self, camera: Camera, camera_service: CameraService, light_type: str) -> None:
         self._device = camera
         self._service = camera_service
-        self._is_on = False
+        self._light_type = light_type
 
     @token_exception_handler
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the floodlight on."""
         await self._service.floodlight_on(self._device)
 
-        self._is_on = True
+        self._device.floodlight = True
         self._just_updated = True
         self.async_schedule_update_ha_state()
 
@@ -382,7 +391,7 @@ class WyzeCamerafloodlight(LightEntity):
         """Turn the floodlight off."""
         await self._service.floodlight_off(self._device)
 
-        self._is_on = False
+        self._device.floodlight = False
         self._just_updated = True
         self.async_schedule_update_ha_state()
 
@@ -398,11 +407,11 @@ class WyzeCamerafloodlight(LightEntity):
 
     @property
     def name(self) -> str:
-        return f"{self._device.nickname} floodlight"
+        return f"{self._device.nickname} {"Lamp Socket" if self._light_type == "lampsocket" else ("Floodlight" if self._light_type == "floodlight" else "Spotlight")}"
 
     @property
     def unique_id(self):
-        return f"{self._device.mac}-floodlight"
+        return f"{self._device.mac}-{self._light_type}"
 
     @property
     def device_info(self):
@@ -439,7 +448,8 @@ class WyzeCamerafloodlight(LightEntity):
     @property
     def icon(self):
         """Return the icon to use in the frontend."""
-        return "mdi:track-light"
+        
+        return "mdi:lightbulb" if self._light_type == "lampsocket" else ("mdi:track-light" if self._light_type == "floodlight" else "mdi:spotlight")
 
     @property
     def color_mode(self):

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -235,6 +235,7 @@ class WyzeCameraBatterySensor(SensorEntity):
 
     @property
     def device_info(self):
+        """Return the device info."""
         return {
             "identifiers": {
                 (DOMAIN, self._camera.mac)
@@ -245,7 +246,9 @@ class WyzeCameraBatterySensor(SensorEntity):
                     self._camera.mac,
                 )
             },
-            "name": f"{self._camera.nickname}.battery"
+            "name": self._camera.nickname,
+            "model": self._camera.product_model,
+            "manufacturer": "WyzeLabs"
         }
 
     @property

--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -40,8 +40,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
     camera_service = await client.camera_service
     sirens = []
     for camera in await camera_service.get_cameras():
-        # The Campan and V2 cameras don't have a siren
-        if camera.product_model not in ["WYZECP1_JEF", "WYZEC1-JZ"]:
+        # The campan (v1 and 2), v2 camera, and video doorbell pro don't have sirens
+        if camera.product_model not in ["WYZECP1_JEF", "WYZEC1-JZ", "GW_BE1"]:
             sirens.append(WyzeCameraSiren(camera, camera_service))
 
     async_add_entities(sirens, True)

--- a/custom_components/wyzeapi/siren.py
+++ b/custom_components/wyzeapi/siren.py
@@ -40,7 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
     camera_service = await client.camera_service
     sirens = []
     for camera in await camera_service.get_cameras():
-        # The campan (v1 and 2), v2 camera, and video doorbell pro don't have sirens
+        # The campan v1, v2 camera, and video doorbell pro don't have sirens
         if camera.product_model not in ["WYZECP1_JEF", "WYZEC1-JZ", "GW_BE1"]:
             sirens.append(WyzeCameraSiren(camera, camera_service))
 

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -25,7 +25,7 @@ from .token_manager import token_exception_handler
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
 SCAN_INTERVAL = timedelta(seconds=30)
-MOTION_SWITCH_UNSUPPORTED = ["GW_BE1"]  # Video doorbell pro
+MOTION_SWITCH_UNSUPPORTED = ["GW_BE1", "GW_GC1", "GW_GC2"]  # Video doorbell pro, OG, OG 3x Telephoto
 POWER_SWITCH_UNSUPPORTED = ["GW_BE1"]  # Video doorbell pro (device has no off function)
 
 # noinspection DuplicatedCode


### PR DESCRIPTION
I tested and fixed many of the control entities in this integration.  I also added some that were unavailable and removed some that are not applicable to the device they are on.

Note: These changes depend on changes made in https://github.com/SecKatie/wyzeapy/pull/91

Note: I squashed all my commits into one.  This is the first major HA contribution I made so I wanted to clean up all the commits where I was troubleshooting the HACS integration installation stuff.

## Changes
- Implemented Battery Cam Pro Spotlight
- Fixed Battery Cam Pro Notification Toggle
- Fixed Battery Cam Pro Event Recording (Motion) Toggle
- Fixed Battery Cam Pro Power
- Fixed Battery Cam Pro Siren
- Fixed Floodlight Pro Floodlight
- Fixed Floodlight Pro Notification Toggle
- Fixed Floodlight Pro Event Recording (Motion) Toggle
- Fixed Floodlight Pro Power
- Fixed Floodlight Pro Siren
- Removed Motion Detection Toggle from Video Doorbell Pro (Didn’t work, can’t fix)
- Removed Power Toggle from Video Doorbell Pro (Device does not have that function)
- Removed Siren Toggle from Video Doorbell Pro (Device does not have that function)
- Fixed OG Cam Notification Toggle
- Fixed OG Cam Event Recording (Motion) Toggle
- Fixed OG Cam Power
- Fixed OG Cam Siren
- Implemented V4 Cam Lamp Socket Accessory (Didn’t test with v3, but should work)
- Removed Floodlight Toggle fromV3 Cams without Floodlight Accessory
- Fixed Wyze Cam Outdoor Notification Toggle
- Fixed Wyze Cam Outdoor Event Recording (Motion) Toggle
- Fixed Wyze Cam Outdoor Power
- Fixed Wyze Cam Outdoor Siren


## Not Working (Proprietary/Tutk Communication Protocol)
- V4 Cam Internal Spotlight
- V3 Pro Cam Internal Spotlight
- OG Cam Internal Spotlight


## Could Not Get Working/Needs Testing
- Video Doorbell Pro Notification Toggle unavailable
    - I can confirm the API works, but the toggle appears grayed out in HA.  The device.available attribute is False in HA.  Suggestions?
- V3 Cam Lamp Socket Toggle
    - Don’t have one setup to test.
- Video Doorbell Pro Motion Toggle
    - Request does not appear in proxy…  Not sure what i'm missing.
- OG Cam siren is stateless
    - Not sure the names of the properties for the OG cam.  The app makes a request to get iot props for the other devices using the devicemgmt api (FLP, BCP), so I can see the list of possible properties, but the OG does not do this.  Other notification and motion detection properties are the same, but siren returns None.
- Some toggles revert their state after toggling, causing a desync between the device and HA.