### PR TITLE
Update load and unload platform

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -120,10 +120,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     options_dict = {BULB_LOCAL_CONTROL: config_entry.options.get(BULB_LOCAL_CONTROL, DEFAULT_LOCAL_CONTROL)}
     hass.config_entries.async_update_entry(config_entry, options=options_dict)
 
-    for platform in PLATFORMS:
-        hass.create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     mac_addresses = await client.unique_device_ids
 
@@ -167,15 +164,4 @@ async def options_update_listener(
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, platform)
-                for platform in PLATFORMS
-            ]
-        )
-    )
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)


### PR DESCRIPTION
Use `hass.config_entries.async_forward_entry_setups` for setup. Gets rid of the depreciation warning and complies with the blog post here: 

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups

Also switch to the preferred `async_unload_platforms` method.