### PR TITLE
Update stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,3 +21,4 @@ jobs:
           days-before-pr-stale: 45
           days-before-issue-close: 5
           days-before-pr-close: 10
+          exempt-issue-labels: enhancement, todo

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,4 +21,4 @@ jobs:
           days-before-pr-stale: 45
           days-before-issue-close: 5
           days-before-pr-close: 10
-          exempt-issue-labels: enhancement, todo
+          exempt-issue-labels: 'enhancement, todo'


### PR DESCRIPTION
Feel free to say no, but I would like to add exceptions to the stale bot for a couple labels to keep them from going stale.