### PR TITLE
Add GW_GC1 and GW_GC2 to MOTION_SWITCH_UNSUPPORTED

### DIFF
--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -25,7 +25,7 @@ from .token_manager import token_exception_handler
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
 SCAN_INTERVAL = timedelta(seconds=30)
-MOTION_SWITCH_UNSUPPORTED = ["GW_BE1", "LD_CFP"]  # Doorbell Cam, Floodlight Pro
+MOTION_SWITCH_UNSUPPORTED = ["GW_BE1", "GW_GC1", "GW_GC2", "LD_CFP"]  # Doorbell Cam, Floodlight Pro
 
 # noinspection DuplicatedCode
 @token_exception_handler

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -25,7 +25,7 @@ from .token_manager import token_exception_handler
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by Wyze"
 SCAN_INTERVAL = timedelta(seconds=30)
-MOTION_SWITCH_UNSUPPORTED = ["GW_BE1", "GW_GC1", "GW_GC2", "LD_CFP"]  # Doorbell Cam, Floodlight Pro
+MOTION_SWITCH_UNSUPPORTED = ["GW_BE1", "GW_GC1", "GW_GC2", "LD_CFP"]  # Doorbell Cam, OG, OG 3x Telephoto, Floodlight Pro
 
 # noinspection DuplicatedCode
 @token_exception_handler


### PR DESCRIPTION
Add GW_GC1 and GW_GC2 to list of cameras not supporting motion (or any streaming video/audio feed at all), otherwise the log is spammed quite excessively with exceptions.