### PR TITLE
Add hint to login page

### DIFF
--- a/custom_components/wyzeapi/strings.json
+++ b/custom_components/wyzeapi/strings.json
@@ -8,7 +8,11 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "keyid": "[%key:common::config_flow::data::key_id%]",
-          "apikey": "[%key:common::config_flow::data::api_key%]"
+          "apikey": "[%key:common::config_flow::data::api_key%]",
+        },
+        "data_description": {
+          "username": "Wyze or 3rd party OAuth email address",
+          "password": "Wyze or 3rd party OAuth password"
         }
       },
       "2fa": {

--- a/custom_components/wyzeapi/strings.json
+++ b/custom_components/wyzeapi/strings.json
@@ -8,7 +8,7 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "keyid": "[%key:common::config_flow::data::key_id%]",
-          "apikey": "[%key:common::config_flow::data::api_key%]",
+          "apikey": "[%key:common::config_flow::data::api_key%]"
         },
         "data_description": {
           "username": "Wyze or 3rd party OAuth email address",

--- a/custom_components/wyzeapi/translations/en.json
+++ b/custom_components/wyzeapi/translations/en.json
@@ -18,7 +18,11 @@
                     "password": "Password",
                     "key_id": "Keyid",
                     "api_key": "Apikey"
-                }
+                },
+                "data_description": {
+                    "username": "Wyze or 3rd party OAuth email address",
+                    "password": "Wyze or 3rd party OAuth password"
+                  }
             },
             "2fa": {
                 "title": "Enter Wyze 2FA Verification Code",


### PR DESCRIPTION
Add hint about using 3rd party Oath login/password to the login page.

Discussed in https://github.com/SecKatie/ha-wyzeapi/issues/631