### PR TITLE
feat: add sprinkler support

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -29,7 +29,8 @@ PLATFORMS = [
     "alarm_control_panel",
     "sensor",
     "siren",
-    "cover"
+    "cover",
+    "number"
 ]  # Fixme: Re add scene
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/wyzeapi/number.py
+++ b/custom_components/wyzeapi/number.py
@@ -1,0 +1,131 @@
+"""Platform for number integration."""
+
+import logging
+from typing import Any, Callable, List
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from wyzeapy import Wyzeapy
+from wyzeapy.services.irrigation_service import IrrigationService, IrrigationDevice, Zone
+
+from .const import DOMAIN, CONF_CLIENT
+from .token_manager import token_exception_handler
+
+_LOGGER = logging.getLogger(__name__)
+
+@token_exception_handler
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[List[Any], bool], None],
+) -> None:
+    """Set up the WyzeApi number platform."""
+    _LOGGER.debug("Creating new WyzeApi number component")
+    client: Wyzeapy = hass.data[DOMAIN][config_entry.entry_id][CONF_CLIENT]
+    irrigation_service = await client.irrigation_service
+
+    # Get all irrigation devices
+    irrigation_devices = await irrigation_service.get_irrigations()
+    
+    # Create a number entity for each zone in each irrigation device
+    entities = []
+    for device in irrigation_devices:
+        # Update the device to get its zones
+        device = await irrigation_service.update(device)
+        for zone in device.zones:
+            entities.append(WyzeIrrigationQuickrunDuration(irrigation_service, device, zone))
+
+    async_add_entities(entities, True)
+
+class WyzeIrrigationQuickrunDuration(NumberEntity):
+    """Representation of a Wyze Irrigation Zone Quickrun Duration."""
+
+    def __init__(self, service: IrrigationService, device: IrrigationDevice, zone: Zone) -> None:
+        """Initialize the irrigation zone quickrun duration."""
+        self._service = service
+        self._device = device
+        self._zone = zone
+
+    @property
+    def name(self) -> str:
+        """Return the name of the zone quickrun duration."""
+        return f"{self._device.nickname} - {self._zone.name} Quickrun Duration"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID for the zone quickrun duration."""
+        return f"{self._device.mac}-zone-{self._zone.zone_number}-quickrun-duration"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device.mac)},
+            name=self._device.nickname,
+            manufacturer="WyzeLabs",
+            model=self._device.product_model,
+        )
+
+    @property
+    def value(self) -> float:
+        """Return the current value."""
+        return float(self._zone.quickrun_duration)
+
+    @property
+    def min_value(self) -> float:
+        """Return the minimum value."""
+        return 1.0
+
+    @property
+    def max_value(self) -> float:
+        """Return the maximum value."""
+        return 3600.0  # 1 hour
+
+    @property
+    def step(self) -> float:
+        """Return the step value."""
+        return 1.0
+
+    @property
+    def mode(self) -> NumberMode:
+        """Return the mode of the number entity."""
+        return NumberMode.BOX
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Return the unit of measurement."""
+        return "s"
+
+    async def async_set_value(self, value: float) -> None:
+        """Set the value."""
+        await self._service.set_zone_quickrun_duration(
+            self._device,
+            self._zone.zone_number,
+            int(value)
+        )
+        self._zone.quickrun_duration = int(value)
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}-irrigation-{self._device.mac}",
+                self._handle_update,
+            )
+        )
+
+    @callback
+    def _handle_update(self, device: IrrigationDevice) -> None:
+        """Handle updates to the device."""
+        self._device = device
+        # Find the updated zone
+        for zone in device.zones:
+            if zone.zone_number == self._zone.zone_number:
+                self._zone = zone
+                break
+        self.async_write_ha_state() 

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -19,6 +19,7 @@ from wyzeapy.services.camera_service import Camera
 from wyzeapy.services.switch_service import Switch
 from wyzeapy.services.bulb_service import Bulb
 from wyzeapy.types import Device, Event, DeviceTypes
+from wyzeapy.services.irrigation_service import IrrigationService, IrrigationDevice, Zone
 
 from .const import CAMERA_UPDATED, LIGHT_UPDATED
 from .const import DOMAIN, CONF_CLIENT, WYZE_CAMERA_EVENT, WYZE_NOTIFICATION_TOGGLE
@@ -52,6 +53,7 @@ async def async_setup_entry(
     wall_switch_service = await client.wall_switch_service
     camera_service = await client.camera_service
     bulb_service = await client.bulb_service
+    irrigation_service = await client.irrigation_service
 
     switches: List[SwitchEntity] = [
         WyzeSwitch(switch_service, switch)
@@ -83,6 +85,16 @@ async def async_setup_entry(
     for bulb in bulb_switches:
         if bulb.type is DeviceTypes.LIGHTSTRIP:
             switches.extend([WzyeLightstripSwitch(bulb_service, bulb)])
+
+    # Get all irrigation devices
+    irrigation_devices = await irrigation_service.get_irrigations()
+    
+    # Create a switch entity for each zone in each irrigation device
+    for device in irrigation_devices:
+        # Update the device to get its zones
+        device = await irrigation_service.update(device)
+        for zone in device.zones:
+            switches.append(WyzeIrrigationZone(irrigation_service, device, zone))
 
     async_add_entities(switches, True)
 
@@ -578,3 +590,86 @@ class WzyeLightstripSwitch(SwitchEntity):
                 self.handle_light_update,
             )
         )
+
+
+class WyzeIrrigationZone(SwitchEntity):
+    """Representation of a Wyze Irrigation Zone."""
+
+    def __init__(self, service: IrrigationService, device: IrrigationDevice, zone: Zone) -> None:
+        """Initialize the irrigation zone."""
+        self._service = service
+        self._device = device
+        self._zone = zone
+        self._is_running = False
+
+    @property
+    def name(self) -> str:
+        """Return the name of the zone."""
+        return f"{self._device.nickname} - {self._zone.name}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the zone is running."""
+        return self._is_running
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID for the zone."""
+        return f"{self._device.mac}-zone-{self._zone.zone_number}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device.mac)},
+            name=self._device.nickname,
+            manufacturer="WyzeLabs",
+            model=self._device.product_model,
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return entity specific state attributes."""
+        return {
+            "zone_number": self._zone.zone_number,
+            "zone_id": self._zone.zone_id,
+            "enabled": self._zone.enabled,
+            "quickrun_duration": self._zone.quickrun_duration,
+        }
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the zone on."""
+        await self._service._irrigation_start_zone(
+            self._device,
+            self._zone.zone_number,
+            self._zone.quickrun_duration
+        )
+        self._is_running = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the zone off."""
+        await self._service._irrigation_stop_running_schedule(self._device)
+        self._is_running = False
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}-irrigation-{self._device.mac}",
+                self._handle_update,
+            )
+        )
+
+    @callback
+    def _handle_update(self, device: IrrigationDevice) -> None:
+        """Handle updates to the device."""
+        self._device = device
+        # Find the updated zone
+        for zone in device.zones:
+            if zone.zone_number == self._zone.zone_number:
+                self._zone = zone
+                break
+        self.async_write_ha_state()


### PR DESCRIPTION
This PR adds support for my irrigation api work in this other PR https://github.com/SecKatie/wyzeapy/pull/127 and related issue https://github.com/SecKatie/ha-wyzeapi/issues/230

Again, my first time adding to a home assistant component, but ive added my code to the sensor.py, switch.py and a new number.py.

Each irrigation device has multiple zones. The parent device has several sensors (RSSI, wifimac, ip address, etc), and then the zones are represented as switches. they have attributes as well (name, id, etc), but my thought in home assistant is to be able to turn them on and off like a switch. The number entity is how long the zone should run for (1-3600 seconds).

Happy to make corrections, but i need the api work merged before i can test much more here