### PR TITLE
More gracefully handle bluetooth unavailability

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.check_config import HomeAssistantConfig
+from homeassistant.components import bluetooth
 from wyzeapy import Wyzeapy
 from wyzeapy.exceptions import AccessTokenError
 from wyzeapy.wyze_auth_lib import Token
@@ -187,6 +188,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 async def setup_coordinators(hass: HomeAssistant, config_entry: ConfigEntry, client: Wyzeapy):
+    """Set up coordinators for Wyze devices that require Bluetooth."""
+    # Check if Bluetooth is active and functioning
+    if bluetooth.async_scanner_count(hass, connectable=True) == 0:
+        _LOGGER.info("Bluetooth is not active or no scanners available. Skipping WyzeLockBoltCoordinator setup.")
+        return
+    
     lock_service = await client.lock_service
     for lock in await lock_service.get_locks():
         if lock.product_model == "YD_BT1":


### PR DESCRIPTION
More gracefully handle bluetooth unavailability:
* If there's no active bluetooth coordinator, then don't try to set up Bolt Locks
* If the Bolt Lock cannot be found (e.g. it's not in bluetooth range, it's out of batteries, etc.) then throw more informative / correct errors

Error messages are more informative, but don't produce a traceback,
```
homeassistant  | 2025-09-25 11:53:27.116 ERROR (MainThread) [custom_components.wyzeapi.coordinator] Error fetching Wyze Lock State Updater data: Could not find BLE device Alleyway Lock with address FC:4D:6A:24:03:49. Device may not be in range.
```
Also, the device shows up as unavailable (which it did before as well).