### PR TITLE
Reenable binary sensors

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -35,6 +35,7 @@ PLATFORMS = [
     "switch",
     "lock",
     "climate",
+    "binary_sensor",
     "alarm_control_panel",
     "sensor",
     "siren",


### PR DESCRIPTION
This creates entities for Wyze Sense motion and contact sensors as well as camera motion detection.

These both used to use the SensorService.process_update to update themselves, which just hammered the Wyze api in a tight loop (which understandably made Wyze angry).

For the Wyze Sense contact and motion sensors, this change instead uses UpdateManager to only poll every 30 seconds. The sensors are also disabled by default, which should further reduce traffic to the Wyze API.

For the camera motion sensor, it registers for the update events, which shouldn't produce any additional load given that the system is already polling for camera updates.