### PR TITLE
Expose event_category and event_value in wyze_camera_event

### DIFF
--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -456,6 +456,8 @@ class WyzeSwitch(SwitchEntity):
                         "device_mac": switch.mac,
                         "ai_tag_list": _ai_tag_list,
                         "tag_list": event.tag_list,
+                        "event_category": getattr(event, "event_category", None),
+                        "event_value": getattr(event, "event_value", None),
                         "event_screenshot": _screenshot_url,
                         "event_video": _video_url,
                     },


### PR DESCRIPTION
## Summary

The `wyze_camera_event` bus event currently drops two higher-level
classification fields that the raw Wyze event already carries:

- `event_category` (int) — the broad event class
- `event_value` (str) — Wyze's detection code string

Both are present on the `wyzeapy` `Event` object (`event.event_category`,
`event.event_value`) but are not included when `WyzeSwitch` fires
`WYZE_CAMERA_EVENT`, so downstream automations only see the raw
`tag_list` codes. Surfacing these makes it possible to classify events
(e.g. motion vs. sound vs. smart detections) and to map Wyze's event
taxonomy without re-querying the event list.

## Change

Two keys added to the fired payload in `WyzeSwitch.async_update_callback`:

```python
"event_category": getattr(event, "event_category", None),
"event_value": getattr(event, "event_value", None),
```

`getattr(..., None)` is used deliberately: `wyzeapy`'s `Event.__init__`
sets attributes only for keys present in the raw `get_event_list` API
response (the class annotations are type hints, not defaults), so a
plain attribute access could raise `AttributeError` on an event missing
the key. The default of `None` keeps the payload shape stable.

Purely additive — no existing key is changed or removed, so existing
consumers of `wyze_camera_event` are unaffected.

## Testing

Ran live against a real Wyze account: with this change, motion events
fire with `event_category=0` and `event_value='13'` populated in the
payload (previously absent). Verified the two fields appear alongside
the existing `tag_list`/`ai_tag_list` data and that events lacking the
keys do not raise.
