### PR TITLE
Map tag_list codes to friendly labels in wyze_camera_event

### DIFF
--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -19,6 +19,22 @@ RESET_BUTTON_PRESSED = f"{DOMAIN}.reset_button_pressed"
 # EVENT NAMES
 WYZE_CAMERA_EVENT = "wyze_camera_event"
 
+# Cam Plus AI smart-detection object-class codes seen in ``event.tag_list``.
+# Wyze publishes no official map; these are community-documented and
+# cross-corroborated by two independent reverse-engineering efforts:
+# shauntarves/wyze-sdk's ``AiEventType`` enum and JoshuaMulliken/ha-wyzeapi#187.
+# Unknown codes fall back to ``tag_<code>`` so novel kinds still surface.
+WYZE_EVENT_TAG_MAP = {
+    101: "person",
+    102: "vehicle",
+    103: "pet",
+    104: "package",
+    101001: "face",
+    800001: "baby_crying",
+    800002: "dog_barking",
+    800003: "cat_meowing",
+}
+
 BULB_LOCAL_CONTROL = "bulb_local_control"
 DEFAULT_LOCAL_CONTROL = True
 

--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -41,6 +41,7 @@ from .const import (
     DOMAIN,
     LIGHT_UPDATED,
     WYZE_CAMERA_EVENT,
+    WYZE_EVENT_TAG_MAP,
     WYZE_NOTIFICATION_TOGGLE,
 )
 from .token_manager import token_exception_handler
@@ -448,6 +449,14 @@ class WyzeSwitch(SwitchEntity):
                         _screenshot_url = resource["url"]
                     elif resource["type"] == 2:
                         _video_url = resource["url"]
+                # Map the raw integer tag_list codes to friendly object-class
+                # labels (person/vehicle/pet/package/...); unknown codes fall
+                # back to "tag_<code>". The raw tag_list is still emitted for
+                # backward compatibility.
+                _tag_labels = [
+                    WYZE_EVENT_TAG_MAP.get(tag, f"tag_{tag}")
+                    for tag in (event.tag_list or [])
+                ]
                 _LOGGER.debug("Camera: %s has a new event", switch.nickname)
                 self.hass.bus.fire(
                     WYZE_CAMERA_EVENT,
@@ -456,6 +465,7 @@ class WyzeSwitch(SwitchEntity):
                         "device_mac": switch.mac,
                         "ai_tag_list": _ai_tag_list,
                         "tag_list": event.tag_list,
+                        "tag_labels": _tag_labels,
                         "event_screenshot": _screenshot_url,
                         "event_video": _video_url,
                     },


### PR DESCRIPTION
## Summary

The `wyze_camera_event` bus event already emits the raw `event.tag_list`, but those are opaque integer codes (e.g. `[101]`, `[103, 101]`). Cam Plus AI smart-detection actually carries the object class in these codes. This adds a derived **`tag_labels`** field that maps them to friendly strings (`person`, `vehicle`, `pet`, `package`, ...), so automations and templates can read `person`/`pet` directly instead of hard-coding magic numbers.

- New `WYZE_EVENT_TAG_MAP` constant in `const.py`.
- `switch.py` computes `_tag_labels` from `event.tag_list` and adds `"tag_labels"` to the event payload.
- The raw `tag_list` is still emitted unchanged (backward compatible). Unknown codes fall back to `tag_<code>` so novel kinds still surface.

### Mapping source

Wyze publishes no official map. These values are community-documented and cross-corroborated by two independent reverse-engineering efforts:

- [`shauntarves/wyze-sdk`](https://github.com/shauntarves/wyze-sdk) — `AiEventType` enum (`wyze_sdk/models/events/__init__.py`)
- [JoshuaMulliken/ha-wyzeapi#187](https://github.com/JoshuaMulliken/ha-wyzeapi/issues/187)

```
101=person  102=vehicle  103=pet  104=package
101001=face  800001=baby_crying  800002=dog_barking  800003=cat_meowing
```

Verified against live events on a Cam Plus account: `103=pet` is anchored by a cat-flap camera, and `101`/`102`/`104` cluster as person/vehicle/package exactly as the enum predicts. Note that generic motion is conveyed by `event_value` (always `13`), not `tag_list`, so an empty `tag_list` yields an empty `tag_labels` and the consumer decides how to label motion.

## Test plan

- [x] `python -m py_compile` on both files
- [x] `ruff check` passes
- [x] Standalone test of the mapping comprehension across known + unknown codes
- [ ] Maintainer: confirm `tag_labels` appears on a live `wyze_camera_event`