### PR TITLE
Fix ValueError on color_temp_kelvin by coercing RGB floats to int

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -179,9 +179,8 @@ class WyzeLight(LightEntity):
                 self._bulb.color_mode = "2"
 
             self._bulb.color_temp = color_temp
-            self._bulb.color = color_util.color_rgb_to_hex(
-                *color_util.color_temperature_to_rgb(color_temp)
-            )
+            r, g, b = color_util.color_temperature_to_rgb(color_temp)
+            self._bulb.color = color_util.color_rgb_to_hex(int(r), int(g), int(b))
 
         if kwargs.get(ATTR_HS_COLOR) is not None and (
             self._device_type is DeviceTypes.MESH_LIGHT


### PR DESCRIPTION
## Summary

Fixes a `ValueError: Unknown format code 'x' for object of type 'float'` raised on every `light.turn_on` call that includes `color_temp_kelvin` for Wyze color bulbs on Home Assistant 2026.6+. Affected paths include Adaptive Lighting, Circadian Lighting, scenes, scripts, and voice assistants requesting warm or cool white.

## Cause

In `custom_components/wyzeapi/light.py`, the color temperature branch of `async_turn_on` does:

```python
self._bulb.color = color_util.color_rgb_to_hex(
    *color_util.color_temperature_to_rgb(color_temp)
)
```

`color_util.color_temperature_to_rgb` is annotated `tuple[float, float, float]` and returns floats. `color_util.color_rgb_to_hex` is annotated `tuple[int, int, int]` and formats with `f"{r:02x}{g:02x}{b:02x}"`, which raises `ValueError` when the inputs are floats because the `x` specifier requires ints.

## Fix

Unpack the result and cast to int before calling `color_rgb_to_hex`:

```python
r, g, b = color_util.color_temperature_to_rgb(color_temp)
self._bulb.color = color_util.color_rgb_to_hex(int(r), int(g), int(b))
```

Two-line change in one method.

## Why the HS color branch is not changed

The next branch (around line 191) also calls `color_rgb_to_hex` via splat, but `color_util.color_hs_to_RGB` chains to `color_hsv_to_RGB`, which already calls `round(...)` internally and returns `tuple[int, int, int]`. No coercion needed there.

## Testing

- Applied the patch to a production HAOS instance (HA 2026.6.0, wyzeapi 0.1.37) with Adaptive Lighting driving three Wyze Mesh color bulbs.
- Before patch: every `light.turn_on` with `color_temp_kelvin` raised the ValueError. Bulbs did not respond.
- After patch: bulbs respond correctly, no errors in the home-assistant.log over 30+ minutes of normal operation.

## Environment

- HA Version: 2026.6.0
- WyzeApi Version: 0.1.37
- Install: HAOS (Docker)
