### PR TITLE
Add Wyze Air Purifier entities

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -34,6 +34,7 @@ from .token_manager import TokenManager
 PLATFORMS = [
     "light",
     "switch",
+    "fan",
     "lock",
     "climate",
     "alarm_control_panel",

--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -15,6 +15,7 @@ LOCK_UPDATED = f"{DOMAIN}.lock_updated"
 CAMERA_UPDATED = f"{DOMAIN}.camera_updated"
 LIGHT_UPDATED = f"{DOMAIN}.light_updated"
 COVER_UPDATED = f"{DOMAIN}.cover_updated"
+AIR_PURIFIER_UPDATED = f"{DOMAIN}.air_purifier_updated"
 RESET_BUTTON_PRESSED = f"{DOMAIN}.reset_button_pressed"
 # EVENT NAMES
 WYZE_CAMERA_EVENT = "wyze_camera_event"

--- a/custom_components/wyzeapi/fan.py
+++ b/custom_components/wyzeapi/fan.py
@@ -1,0 +1,265 @@
+"""Platform for fan integration."""
+
+from collections.abc import Callable
+import logging
+from typing import Any
+
+from aiohttp.client_exceptions import ClientConnectionError
+from wyzeapy import Wyzeapy
+from wyzeapy.exceptions import AccessTokenError, ParameterError, UnknownApiError
+from wyzeapy.services.air_purifier_service import (
+    AirPurifier,
+    AirPurifierFanMode,
+    AirPurifierService,
+)
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers import device_registry as dr
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
+
+from .const import AIR_PURIFIER_UPDATED, CONF_CLIENT, DOMAIN
+from .token_manager import token_exception_handler
+
+_LOGGER = logging.getLogger(__name__)
+ATTRIBUTION = "Data provided by Wyze"
+
+ORDERED_NAMED_FAN_SPEEDS = [
+    AirPurifierFanMode.MIN.value,
+    AirPurifierFanMode.MID.value,
+    AirPurifierFanMode.MAX.value,
+    AirPurifierFanMode.TURBO.value,
+]
+PRESET_MODES = [
+    AirPurifierFanMode.AUTO.value,
+    AirPurifierFanMode.SLEEP.value,
+]
+
+
+@token_exception_handler
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[list[Any], bool], None],
+) -> None:
+    """Set up Wyze air purifier fan entities."""
+
+    _LOGGER.debug("""Creating new WyzeApi fan component""")
+    client: Wyzeapy = hass.data[DOMAIN][config_entry.entry_id][CONF_CLIENT]
+    air_purifier_service = await client.air_purifier_service
+
+    fans = [
+        WyzeAirPurifierFan(air_purifier_service, air_purifier)
+        for air_purifier in await air_purifier_service.get_air_purifiers()
+    ]
+
+    async_add_entities(fans, True)
+
+
+class WyzeAirPurifierFan(FanEntity):
+    """Representation of a Wyze Air Purifier fan."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_should_poll = False
+    _attr_supported_features = (
+        FanEntityFeature.PRESET_MODE
+        | FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_OFF
+        | FanEntityFeature.TURN_ON
+    )
+    _attr_preset_modes = PRESET_MODES
+    _just_updated = False
+
+    def __init__(
+        self,
+        air_purifier_service: AirPurifierService,
+        air_purifier: AirPurifier,
+    ) -> None:
+        """Initialize the air purifier fan."""
+        self._air_purifier_service = air_purifier_service
+        self._air_purifier = air_purifier
+        self._attr_unique_id = f"{self._air_purifier.mac}-fan"
+
+    @property
+    def device_info(self):
+        """Return device information about this entity."""
+        device_info = {
+            "identifiers": {(DOMAIN, self._air_purifier.mac)},
+            "name": self._air_purifier.nickname,
+            "manufacturer": "WyzeLabs",
+            "model": self._air_purifier.product_model,
+        }
+        if self._air_purifier.app_version:
+            device_info["sw_version"] = self._air_purifier.app_version
+        if self._air_purifier.sn:
+            device_info["serial_number"] = self._air_purifier.sn
+        if self._air_purifier.wifi_mac:
+            device_info["connections"] = {
+                (dr.CONNECTION_NETWORK_MAC, self._air_purifier.wifi_mac)
+            }
+        return device_info
+
+    @property
+    def available(self) -> bool:
+        """Return the connection status of this fan."""
+        return self._air_purifier.available
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the fan is on."""
+        return self._air_purifier.on
+
+    @property
+    def percentage(self) -> int | None:
+        """Return the current fan speed percentage."""
+        if not self._air_purifier.on:
+            return 0
+        if self._air_purifier.fan_mode in ORDERED_NAMED_FAN_SPEEDS:
+            return ordered_list_item_to_percentage(
+                ORDERED_NAMED_FAN_SPEEDS, self._air_purifier.fan_mode
+            )
+        return None
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the active fan preset mode."""
+        if not self._air_purifier.on:
+            return None
+        if self._air_purifier.fan_mode in PRESET_MODES:
+            return self._air_purifier.fan_mode
+        return None
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of supported speeds."""
+        return len(ORDERED_NAMED_FAN_SPEEDS)
+
+    @token_exception_handler
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan."""
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+            return
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
+            return
+
+        try:
+            await self._air_purifier_service.turn_on(self._air_purifier)
+        except (AccessTokenError, ParameterError, UnknownApiError) as err:
+            raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
+        except ClientConnectionError as err:
+            raise HomeAssistantError(err) from err
+        else:
+            self._air_purifier.on = True
+            self._just_updated = True
+            self.async_schedule_update_ha_state()
+
+    @token_exception_handler
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the fan."""
+        try:
+            await self._air_purifier_service.turn_off(self._air_purifier)
+        except (AccessTokenError, ParameterError, UnknownApiError) as err:
+            raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
+        except ClientConnectionError as err:
+            raise HomeAssistantError(err) from err
+        else:
+            self._air_purifier.on = False
+            self._just_updated = True
+            self.async_schedule_update_ha_state()
+
+    @token_exception_handler
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
+        fan_mode = percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, percentage)
+
+        try:
+            if not self._air_purifier.on:
+                await self._air_purifier_service.turn_on(self._air_purifier)
+            await self._air_purifier_service.set_fan_mode(self._air_purifier, fan_mode)
+        except (AccessTokenError, ParameterError, UnknownApiError) as err:
+            raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
+        except ClientConnectionError as err:
+            raise HomeAssistantError(err) from err
+        else:
+            self._air_purifier.on = True
+            self._air_purifier.fan_mode = fan_mode
+            self._just_updated = True
+            self.async_schedule_update_ha_state()
+
+    @token_exception_handler
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan."""
+        if preset_mode not in PRESET_MODES:
+            raise ValueError(f"Unsupported air purifier preset mode: {preset_mode}")
+
+        try:
+            if not self._air_purifier.on:
+                await self._air_purifier_service.turn_on(self._air_purifier)
+            await self._air_purifier_service.set_fan_mode(
+                self._air_purifier, preset_mode
+            )
+        except (AccessTokenError, ParameterError, UnknownApiError) as err:
+            raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
+        except ClientConnectionError as err:
+            raise HomeAssistantError(err) from err
+        else:
+            self._air_purifier.on = True
+            self._air_purifier.fan_mode = preset_mode
+            self._just_updated = True
+            self.async_schedule_update_ha_state()
+
+    @token_exception_handler
+    async def async_update(self) -> None:
+        """Update the entity."""
+        if not self._just_updated:
+            self._air_purifier = await self._air_purifier_service.update(
+                self._air_purifier
+            )
+        else:
+            self._just_updated = False
+
+    @callback
+    def async_update_callback(self, air_purifier: AirPurifier) -> None:
+        """Update the fan state."""
+        self._air_purifier = air_purifier
+        self._dispatch_update()
+        self.async_schedule_update_ha_state()
+
+    @callback
+    def _dispatch_update(self) -> None:
+        """Notify sibling air purifier entities of device updates."""
+        async_dispatcher_send(
+            self.hass,
+            f"{AIR_PURIFIER_UPDATED}-{self._air_purifier.mac}",
+            self._air_purifier,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to update events."""
+        self._air_purifier.callback_function = self.async_update_callback
+        self._air_purifier_service.register_updater(self._air_purifier, 30)
+        await self._air_purifier_service.start_update_manager()
+        return await super().async_added_to_hass()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister updater on removal."""
+        self._air_purifier_service.unregister_updater(self._air_purifier)

--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/SecKatie/ha-wyzeapi/issues",
   "loggers": ["custom_components.wyzeapi"],
   "requirements": [
-    "wyzeapy>=0.5.33,<0.6",
+    "wyzeapy>=0.6.0,<0.7",
     "websockets"
   ],
   "version": "0.1.37"

--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/SecKatie/ha-wyzeapi/issues",
   "loggers": ["custom_components.wyzeapi"],
   "requirements": [
-    "wyzeapy>=0.6.0,<0.7",
+    "wyzeapy>=0.6.1,<0.7",
     "websockets"
   ],
   "version": "0.1.38"

--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/SecKatie/ha-wyzeapi/issues",
   "loggers": ["custom_components.wyzeapi"],
   "requirements": [
-    "wyzeapy>=0.5.33,<0.6",
+    "wyzeapy>=0.6.0,<0.7",
     "websockets"
   ],
   "version": "0.1.38"

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 from wyzeapy import Wyzeapy
+from wyzeapy.services.air_purifier_service import AirPurifier
 from wyzeapy.services.camera_service import Camera
 from wyzeapy.services.irrigation_service import Irrigation, IrrigationService
 from wyzeapy.services.lock_service import Lock
@@ -36,6 +37,7 @@ from homeassistant.helpers.event import (
 )
 
 from .const import (
+    AIR_PURIFIER_UPDATED,
     CAMERA_UPDATED,
     CONF_CLIENT,
     DOMAIN,
@@ -71,6 +73,7 @@ async def async_setup_entry(
     camera_service = await client.camera_service
     switch_usage_service = await client.switch_usage_service
     irrigation_service = await client.irrigation_service
+    air_purifier_service = await client.air_purifier_service
 
     locks = await lock_service.get_locks()
     sensors = []
@@ -94,6 +97,11 @@ async def async_setup_entry(
         if plug.product_model in OUTDOOR_PLUGS:
             sensors.append(WyzePlugEnergySensor(plug, switch_usage_service))
             sensors.append(WyzePlugDailyEnergySensor(plug))
+
+    air_purifiers = await air_purifier_service.get_air_purifiers()
+    for air_purifier in air_purifiers:
+        sensors.append(WyzeAirPurifierAQISensor(air_purifier))
+        sensors.append(WyzeAirPurifierHourlyMaxAQISensor(air_purifier))
 
     # Get all irrigation devices
     irrigation_devices = await irrigation_service.get_irrigations()
@@ -624,3 +632,140 @@ class WyzeIrrigationSSID(WyzeIrrigationBaseSensor):
     def native_value(self) -> str:
         """Return the SSID."""
         return self._device.ssid
+
+
+class WyzeAirPurifierAirQualitySensor(SensorEntity):
+    """Base class for Wyze Air Purifier air quality sensors."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_device_class = SensorDeviceClass.AQI
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 0
+
+    def __init__(
+        self,
+        air_purifier: AirPurifier,
+    ) -> None:
+        """Initialize the AQI sensor."""
+        self._air_purifier = air_purifier
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this entity."""
+        device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._air_purifier.mac)},
+            name=self._air_purifier.nickname,
+            manufacturer="WyzeLabs",
+            model=self._air_purifier.product_model,
+        )
+        if self._air_purifier.app_version:
+            device_info["sw_version"] = self._air_purifier.app_version
+        if self._air_purifier.sn:
+            device_info["serial_number"] = self._air_purifier.sn
+        if self._air_purifier.wifi_mac:
+            device_info["connections"] = {
+                (dr.CONNECTION_NETWORK_MAC, self._air_purifier.wifi_mac)
+            }
+        return device_info
+
+    @property
+    def available(self) -> bool:
+        """Return the connection status of this sensor."""
+        return self._air_purifier.available
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return device attributes of the entity."""
+        return {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            "device model": self._air_purifier.product_model,
+        }
+
+    @callback
+    def handle_air_purifier_update(self, air_purifier: AirPurifier) -> None:
+        """Handle air purifier updates."""
+        self._air_purifier = air_purifier
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Add listener on startup."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{AIR_PURIFIER_UPDATED}-{self._air_purifier.mac}",
+                self.handle_air_purifier_update,
+            )
+        )
+
+
+class WyzeAirPurifierAQISensor(WyzeAirPurifierAirQualitySensor):
+    """Representation of a Wyze Air Purifier current AQI sensor."""
+
+    _attr_name = "Current AQI"
+
+    def __init__(
+        self,
+        air_purifier: AirPurifier,
+    ) -> None:
+        """Initialize the current AQI sensor."""
+        super().__init__(air_purifier)
+        self._attr_unique_id = f"{self._air_purifier.mac}-aqi"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the current AQI value."""
+        return self._air_purifier.aqi
+
+
+class WyzeAirPurifierHourlyMaxAQISensor(WyzeAirPurifierAirQualitySensor):
+    """Representation of a Wyze Air Purifier hourly max AQI sensor."""
+
+    _attr_name = "Hourly Max AQI"
+
+    def __init__(
+        self,
+        air_purifier: AirPurifier,
+    ) -> None:
+        """Initialize the hourly max AQI sensor."""
+        super().__init__(air_purifier)
+        self._attr_unique_id = f"{self._air_purifier.mac}-hourly-max-aqi"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the hourly max AQI value."""
+        return self._air_purifier.max_hourly_aqi
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return device attributes of the entity."""
+        attributes = super().extra_state_attributes
+        attributes.update(
+            {
+                "hour_start": self._timestamp_attribute(
+                    self._air_purifier.max_hourly_aqi_start_time
+                ),
+                "hour_end": self._timestamp_attribute(
+                    self._air_purifier.max_hourly_aqi_start_time,
+                    offset=datetime.timedelta(hours=1),
+                ),
+                "sampled_until": self._timestamp_attribute(
+                    self._air_purifier.max_hourly_aqi_end_time
+                ),
+            }
+        )
+        return attributes
+
+    @staticmethod
+    def _timestamp_attribute(
+        timestamp: int | None, offset: datetime.timedelta | None = None
+    ) -> str | None:
+        """Return an ISO formatted timestamp attribute."""
+        if timestamp is None:
+            return None
+
+        value = datetime.datetime.fromtimestamp(timestamp, datetime.UTC)
+        if offset is not None:
+            value += offset
+        return value.isoformat()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.13.2,<3.14"
 
 dependencies = [
     "homeassistant>=2026.1.0",
-    "wyzeapy>=0.5.33,<0.6.0",
+    "wyzeapy>=0.6.0,<0.7.0",
     "websockets",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.13.2,<3.14"
 
 dependencies = [
     "homeassistant>=2026.1.0",
-    "wyzeapy>=0.6.0,<0.7.0",
+    "wyzeapy>=0.6.1,<0.7.0",
     "websockets",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -754,7 +754,7 @@ dev = [
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.1.0" },
     { name = "websockets" },
-    { name = "wyzeapy", specifier = ">=0.6.0,<0.7.0" },
+    { name = "wyzeapy", specifier = ">=0.6.1,<0.7.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1908,16 +1908,17 @@ wheels = [
 
 [[package]]
 name = "wyzeapy"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
     { name = "aiohttp" },
+    { name = "certifi" },
     { name = "pycryptodome" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/25/3684f60f57d1f09fadfd4f39e2d1e524da60ac3a9e2640d7088a16e14179/wyzeapy-0.6.0.tar.gz", hash = "sha256:900944dee5e055b2db44f38c075893b63df5825275a823ee26e8129d463826a8", size = 632081, upload-time = "2026-06-07T18:56:13.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/8d/48ad4ab31e41eccc32099e4a31b9883ead1e7324c9236e2683856be78e40/wyzeapy-0.6.1.tar.gz", hash = "sha256:799cc0598988a9b2692161f75bb6b8c65fedb57772175af8a118e7df45ba384b", size = 637301, upload-time = "2026-07-14T21:17:42.823Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/85/11b6124c5902225a08806701407e175db696a3ebf2987d62963e0edefc4b/wyzeapy-0.6.0-py3-none-any.whl", hash = "sha256:14bfd5e96c0201bf0ce0bb3c1f368fa1a0ba25fb6799927c5330226389cfd97c", size = 51453, upload-time = "2026-06-07T18:56:14.491Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/29/095dcba07048291c8010c1327920788b74008e24c5a966432b05b9c22ea5/wyzeapy-0.6.1-py3-none-any.whl", hash = "sha256:82c390fa1476e4c66783a928a0a01f88f393c58407181716d24396e5fb96fe61", size = 53592, upload-time = "2026-07-14T21:17:41.354Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ dev = [
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.1.0" },
     { name = "websockets" },
-    { name = "wyzeapy", specifier = ">=0.5.33,<0.6.0" },
+    { name = "wyzeapy", specifier = ">=0.6.0,<0.7.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2369,16 +2369,16 @@ wheels = [
 
 [[package]]
 name = "wyzeapy"
-version = "0.5.33"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
     { name = "aiohttp" },
     { name = "pycryptodome" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/2d/8190a7938182577b27c17d5f6882f7ddf32b27e52445b43de72f3f58aafc/wyzeapy-0.5.33.tar.gz", hash = "sha256:4f32a284a992aabfff617b2c7b7d8fdda95da5c5cec4edb8d14fa6aa3f7a3413", size = 628819, upload-time = "2026-04-19T18:00:59.729Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/25/3684f60f57d1f09fadfd4f39e2d1e524da60ac3a9e2640d7088a16e14179/wyzeapy-0.6.0.tar.gz", hash = "sha256:900944dee5e055b2db44f38c075893b63df5825275a823ee26e8129d463826a8", size = 632081, upload-time = "2026-06-07T18:56:13.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9a/10332d958c159411f2226f979feb52686d04083842c3ef0a390025ea0944/wyzeapy-0.5.33-py3-none-any.whl", hash = "sha256:79bcf77295fde285e675b319e51a16d1f5c5d42aedfc08d0639001f637bf8d64", size = 49140, upload-time = "2026-04-19T18:00:58.746Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/85/11b6124c5902225a08806701407e175db696a3ebf2987d62963e0edefc4b/wyzeapy-0.6.0-py3-none-any.whl", hash = "sha256:14bfd5e96c0201bf0ce0bb3c1f368fa1a0ba25fb6799927c5330226389cfd97c", size = 51453, upload-time = "2026-06-07T18:56:14.491Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -754,7 +754,7 @@ dev = [
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.1.0" },
     { name = "websockets" },
-    { name = "wyzeapy", specifier = ">=0.5.33,<0.6.0" },
+    { name = "wyzeapy", specifier = ">=0.6.0,<0.7.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1908,16 +1908,16 @@ wheels = [
 
 [[package]]
 name = "wyzeapy"
-version = "0.5.33"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
     { name = "aiohttp" },
     { name = "pycryptodome" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/2d/8190a7938182577b27c17d5f6882f7ddf32b27e52445b43de72f3f58aafc/wyzeapy-0.5.33.tar.gz", hash = "sha256:4f32a284a992aabfff617b2c7b7d8fdda95da5c5cec4edb8d14fa6aa3f7a3413", size = 628819, upload-time = "2026-04-19T18:00:59.729Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/25/3684f60f57d1f09fadfd4f39e2d1e524da60ac3a9e2640d7088a16e14179/wyzeapy-0.6.0.tar.gz", hash = "sha256:900944dee5e055b2db44f38c075893b63df5825275a823ee26e8129d463826a8", size = 632081, upload-time = "2026-06-07T18:56:13.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9a/10332d958c159411f2226f979feb52686d04083842c3ef0a390025ea0944/wyzeapy-0.5.33-py3-none-any.whl", hash = "sha256:79bcf77295fde285e675b319e51a16d1f5c5d42aedfc08d0639001f637bf8d64", size = 49140, upload-time = "2026-04-19T18:00:58.746Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/85/11b6124c5902225a08806701407e175db696a3ebf2987d62963e0edefc4b/wyzeapy-0.6.0-py3-none-any.whl", hash = "sha256:14bfd5e96c0201bf0ce0bb3c1f368fa1a0ba25fb6799927c5330226389cfd97c", size = 51453, upload-time = "2026-06-07T18:56:14.491Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Wyze Air Purifier (`CO_AP1`) support for issue #801.
- Expose air purifiers as Home Assistant `fan` entities with power, auto/sleep presets, and manual speed control.
- Add Current AQI and Hourly Max AQI sensors for each purifier.
- Update the minimum `wyzeapy` requirement to the released `0.6.1` AQI support.

## Update Flow
- The purifier fan entity is the only Home Assistant purifier entity registered with the `wyzeapy` update manager.
- On normal device updates, the fan entity dispatches `AIR_PURIFIER_UPDATED` for sibling purifier entities.
- The AQI sensors listen for that dispatcher signal and keep `_attr_should_poll = False`; they do not create their own Home Assistant timer, updater, or direct AQI endpoint calls.
- Dedicated AQI endpoint cadence is handled in `wyzeapy==0.6.1` by the merged SecKatie/wyzeapy#265 changes, which refresh air quality during `AirPurifierService.update()`, reuses cached values between refreshes, skips unavailable devices, and keeps normal fan/device state updates working if AQI refresh fails.

## Dependency
- SecKatie/wyzeapy#262 landed in `wyzeapy==0.6.0` and provides the base air purifier service support used here.
- SecKatie/wyzeapy#265 landed and was released in `wyzeapy==0.6.1`; this PR now requires `wyzeapy>=0.6.1,<0.7`.

## Validation
- `uv run --locked ruff check custom_components/wyzeapi`
- `uv run --locked ruff format --check custom_components/wyzeapi`
- live tested with HACS build `v0.1.38-air-purifier-test.2` for several days on two `CO_AP1` purifiers
- verified fan power, auto/sleep/manual fan modes, Current AQI, and Hourly Max AQI sensors