### PR TITLE
fix(light): turn LIGHT bulbs on/off via run_action (firmware ignores P3 set_property)

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -236,7 +236,12 @@ class WyzeLight(LightEntity):
 
         _LOGGER.debug("Turning on light")
         try:
-            await self._bulb_service.turn_on(self._bulb, self._local_control, options)
+            if self._device_type is DeviceTypes.LIGHT:
+                await self._bulb_service._run_action_list(
+                    self._bulb, [create_pid_pair(PropertyIDs.ON, "1")] + options
+                )
+            else:
+                await self._bulb_service.turn_on(self._bulb, self._local_control, options)
         except (AccessTokenError, ParameterError, UnknownApiError) as err:
             raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
         except ClientConnectionError as err:
@@ -251,7 +256,13 @@ class WyzeLight(LightEntity):
         """Turn off the light."""
         self._local_control = self._config_entry.options.get(BULB_LOCAL_CONTROL)
         try:
-            await self._bulb_service.turn_off(self._bulb, self._local_control)
+            if self._device_type is DeviceTypes.LIGHT:
+                # WLPA19 fw ignores P3 power via set_property_list; the run_action push is honored
+                await self._bulb_service._run_action_list(
+                    self._bulb, [create_pid_pair(PropertyIDs.ON, "0")]
+                )
+            else:
+                await self._bulb_service.turn_off(self._bulb, self._local_control)
         except (AccessTokenError, ParameterError, UnknownApiError) as err:
             raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
         except ClientConnectionError as err:


### PR DESCRIPTION
Fixes #867.

Recent Wyze Bulb firmware (e.g. WLPA19 1.2.0.382) ignores the `P3` power property sent via `device/set_property_list` (Wyze returns SUCCESS but the bulb no-ops), while `auto/run_action_list` (`set_mesh_property`) is honored -- confirmed on-device, repeatably, both directions. Brightness/color_temp are unaffected.

This routes power on/off through `_run_action_list` for `DeviceTypes.LIGHT` bulbs only, leaving mesh bulbs and lightstrips on their existing path. Verified on hardware: on/off, brightness, and color_temp all working.
