### PR TITLE
fix: pre-build wyzeapy SSL context at setup (Wyze API TLS failure on HA 2026.7+)

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -105,6 +105,22 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     key_id = config_entry.data.get(KEY_ID)
     api_key = config_entry.data.get(API_KEY)
 
+    # Pre-build wyzeapy's SSL context (certifi + pinned DigiCert Global Root
+    # CA) off the event loop. Mozilla/certifi removed that root in 2026 but
+    # Wyze's API chain is still anchored to it, so both aiohttp's default
+    # context AND HA's own client context fail with CERTIFICATE_VERIFY_FAILED.
+    # Building it here in the executor avoids a blocking-I/O-in-loop warning
+    # on the first API call.
+    try:
+        from wyzeapy.wyze_auth_lib import get_ssl_context
+
+        await hass.async_add_executor_job(get_ssl_context)
+    except ImportError:  # older wyzeapy without the shared context helper
+        _LOGGER.warning(
+            "wyzeapy does not provide get_ssl_context; TLS to the Wyze API may "
+            "fail on systems whose CA store dropped DigiCert Global Root CA"
+        )
+
     client = await Wyzeapy.create()
     token = None
     if config_entry.data.get(ACCESS_TOKEN):


### PR DESCRIPTION
## Problem

On Home Assistant core 2026.7+ the integration fails setup and loops in `setup_retry`:

```
aiohttp.client_exceptions.ClientConnectorCertificateError: Cannot connect to host api.wyzecam.com:443 ssl:True
[SSLCertVerificationError: certificate verify failed: unable to get local issuer certificate]
```

Root cause: Mozilla removed the legacy **DigiCert Global Root CA** from its root program, so certifi >= 2026.06 (which HA 2026.7 ships) no longer trusts the root that Wyze's API certificate chain is anchored to. The Wyze mobile apps keep working (mobile trust stores still include the root), so users see "works in the app, dead in HA". It typically starts one token lifetime after the HA upgrade, when the first `refresh_token` POST goes out.

The actual TLS fix lives in the library: SecKatie/wyzeapy#279 (certifi + single pinned DigiCert Global Root CA, scoped to wyzeapy's sessions only).

## This PR

Calls the library's `get_ssl_context()` once in `async_setup_entry` via `hass.async_add_executor_job(...)`, so the SSL context (which reads certificate files from disk) is built **off the event loop** instead of lazily inside the first API call — avoiding HA's blocking-call-in-event-loop warning.

Guarded with `try/except ImportError` so the integration still loads cleanly against older wyzeapy versions that don't have the helper (it just logs a warning).

## Verification

Running live on HA core 2026.7.0 (Python 3.14): with wyzeapy#279 installed, the integration recovers immediately — all entities repopulate and token refresh works.

Depends on (but does not require) SecKatie/wyzeapy#279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)