### PR TITLE
Add air purifier tests and preserve auth failures

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -16,3 +16,11 @@ License: Apache-2.0
 Files: .github/*
 Copyright: 2021 Katie Mulliken <katie@mulliken.net>
 License: Apache-2.0
+
+Files: tests/*
+Copyright: 2026 Katie Mulliken <katie@mulliken.net>
+License: Apache-2.0
+
+Files: uv.lock
+Copyright: 2026 Katie Mulliken <katie@mulliken.net>
+License: Apache-2.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/custom_components/wyzeapi/fan.py
+++ b/custom_components/wyzeapi/fan.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from aiohttp.client_exceptions import ClientConnectionError
 from wyzeapy import Wyzeapy
-from wyzeapy.exceptions import AccessTokenError, ParameterError, UnknownApiError
+from wyzeapy.exceptions import ParameterError, UnknownApiError
 from wyzeapy.services.air_purifier_service import (
     AirPurifier,
     AirPurifierFanMode,
@@ -159,7 +159,7 @@ class WyzeAirPurifierFan(FanEntity):
 
         try:
             await self._air_purifier_service.turn_on(self._air_purifier)
-        except (AccessTokenError, ParameterError, UnknownApiError) as err:
+        except (ParameterError, UnknownApiError) as err:
             raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
         except ClientConnectionError as err:
             raise HomeAssistantError(err) from err
@@ -173,7 +173,7 @@ class WyzeAirPurifierFan(FanEntity):
         """Turn off the fan."""
         try:
             await self._air_purifier_service.turn_off(self._air_purifier)
-        except (AccessTokenError, ParameterError, UnknownApiError) as err:
+        except (ParameterError, UnknownApiError) as err:
             raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
         except ClientConnectionError as err:
             raise HomeAssistantError(err) from err
@@ -195,7 +195,7 @@ class WyzeAirPurifierFan(FanEntity):
             if not self._air_purifier.on:
                 await self._air_purifier_service.turn_on(self._air_purifier)
             await self._air_purifier_service.set_fan_mode(self._air_purifier, fan_mode)
-        except (AccessTokenError, ParameterError, UnknownApiError) as err:
+        except (ParameterError, UnknownApiError) as err:
             raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
         except ClientConnectionError as err:
             raise HomeAssistantError(err) from err
@@ -217,7 +217,7 @@ class WyzeAirPurifierFan(FanEntity):
             await self._air_purifier_service.set_fan_mode(
                 self._air_purifier, preset_mode
             )
-        except (AccessTokenError, ParameterError, UnknownApiError) as err:
+        except (ParameterError, UnknownApiError) as err:
             raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
         except ClientConnectionError as err:
             raise HomeAssistantError(err) from err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ packages = ["custom_components"]
 
 [dependency-groups]
 dev = [
+    "aiousbwatcher==1.1.1",
+    "pyserial==3.5",
+    "pytest>=8.0.0,<10.0.0",
+    "pytest-asyncio>=0.23.0,<2.0.0",
     "ruff>=0.12.1",
 ]
 

--- a/tests/test_air_purifier_fan.py
+++ b/tests/test_air_purifier_fan.py
@@ -1,0 +1,227 @@
+"""Tests for Wyze air purifier fan entities."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from aiohttp.client_exceptions import ClientConnectionError
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+import pytest
+from wyzeapy.exceptions import AccessTokenError, ParameterError, UnknownApiError
+
+from custom_components.wyzeapi import PLATFORMS
+from custom_components.wyzeapi import fan as fan_module
+from custom_components.wyzeapi.const import CONF_CLIENT, DOMAIN
+from custom_components.wyzeapi.fan import WyzeAirPurifierFan
+
+
+@pytest.fixture
+def air_purifier() -> SimpleNamespace:
+    """Return a representative air purifier."""
+    return SimpleNamespace(
+        mac="AA:BB:CC:DD:EE:FF",
+        nickname="Office Purifier",
+        product_model="CO_AP1",
+        available=True,
+        on=True,
+        fan_mode="min",
+        app_version="1.2.3",
+        sn="PURIFIER123",
+        wifi_mac="11:22:33:44:55:66",
+    )
+
+
+@pytest.fixture
+def service() -> SimpleNamespace:
+    """Return a mocked air purifier service."""
+    return SimpleNamespace(
+        get_air_purifiers=AsyncMock(return_value=[]),
+        register_updater=Mock(),
+        unregister_updater=Mock(),
+        start_update_manager=AsyncMock(),
+        turn_on=AsyncMock(),
+        turn_off=AsyncMock(),
+        set_fan_mode=AsyncMock(),
+        update=AsyncMock(),
+    )
+
+
+@pytest.fixture
+def entity(
+    service: SimpleNamespace, air_purifier: SimpleNamespace
+) -> WyzeAirPurifierFan:
+    """Return an air purifier fan entity."""
+    fan = WyzeAirPurifierFan(service, air_purifier)
+    fan.async_schedule_update_ha_state = Mock()
+    return fan
+
+
+def test_fan_platform_is_registered() -> None:
+    """The integration loads the air purifier fan platform."""
+    assert "fan" in PLATFORMS
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_adds_air_purifier_fans(
+    service: SimpleNamespace,
+    air_purifier: SimpleNamespace,
+) -> None:
+    """The real fan platform setup creates purifier entities."""
+    service.get_air_purifiers.return_value = [air_purifier]
+    service_future = asyncio.Future()
+    service_future.set_result(service)
+    client = SimpleNamespace(air_purifier_service=service_future)
+    config_entry = SimpleNamespace(entry_id="entry-id")
+    hass = SimpleNamespace(
+        data={DOMAIN: {config_entry.entry_id: {CONF_CLIENT: client}}}
+    )
+    async_add_entities = Mock()
+
+    await fan_module.async_setup_entry(hass, config_entry, async_add_entities)
+
+    entities, update_before_add = async_add_entities.call_args.args
+    assert update_before_add is True
+    assert len(entities) == 1
+    assert isinstance(entities[0], WyzeAirPurifierFan)
+    service.get_air_purifiers.assert_awaited_once_with()
+
+
+def test_state_and_device_information(
+    entity: WyzeAirPurifierFan, air_purifier: SimpleNamespace
+) -> None:
+    """Fan state and device metadata reflect the library model."""
+    assert entity.available is True
+    assert entity.is_on is True
+    assert entity.percentage == 25
+    assert entity.preset_mode is None
+    assert entity.speed_count == 4
+    assert entity.unique_id == "AA:BB:CC:DD:EE:FF-fan"
+    assert entity.device_info == {
+        "identifiers": {("wyzeapi", "AA:BB:CC:DD:EE:FF")},
+        "name": "Office Purifier",
+        "manufacturer": "WyzeLabs",
+        "model": "CO_AP1",
+        "sw_version": "1.2.3",
+        "serial_number": "PURIFIER123",
+        "connections": {("mac", "11:22:33:44:55:66")},
+    }
+
+    air_purifier.fan_mode = "auto"
+    assert entity.percentage is None
+    assert entity.preset_mode == "auto"
+
+    air_purifier.on = False
+    assert entity.percentage == 0
+    assert entity.preset_mode is None
+
+
+@pytest.mark.asyncio
+async def test_set_percentage_turns_on_and_sets_mode(
+    entity: WyzeAirPurifierFan,
+    service: SimpleNamespace,
+    air_purifier: SimpleNamespace,
+) -> None:
+    """Selecting a speed turns on the purifier and updates its mode."""
+    air_purifier.on = False
+
+    await entity.async_set_percentage(50)
+
+    service.turn_on.assert_awaited_once_with(air_purifier)
+    service.set_fan_mode.assert_awaited_once_with(air_purifier, "mid")
+    assert air_purifier.on is True
+    assert air_purifier.fan_mode == "mid"
+    entity.async_schedule_update_ha_state.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_turn_off_updates_optimistic_state(
+    entity: WyzeAirPurifierFan,
+    service: SimpleNamespace,
+    air_purifier: SimpleNamespace,
+) -> None:
+    """Turning off updates the model after the API call succeeds."""
+    await entity.async_turn_off()
+
+    service.turn_off.assert_awaited_once_with(air_purifier)
+    assert air_purifier.on is False
+    entity.async_schedule_update_ha_state.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_updater_lifecycle(
+    entity: WyzeAirPurifierFan,
+    service: SimpleNamespace,
+    air_purifier: SimpleNamespace,
+) -> None:
+    """The fan owns updater registration and manager startup."""
+    await entity.async_added_to_hass()
+
+    assert air_purifier.callback_function == entity.async_update_callback
+    service.register_updater.assert_called_once_with(air_purifier, 30)
+    service.start_update_manager.assert_awaited_once_with()
+
+    await entity.async_will_remove_from_hass()
+
+    service.unregister_updater.assert_called_once_with(air_purifier)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_exception"),
+    [
+        (AccessTokenError("expired token"), ConfigEntryAuthFailed),
+        (ParameterError("invalid request"), HomeAssistantError),
+        (UnknownApiError("unexpected response"), HomeAssistantError),
+        (ClientConnectionError("offline"), HomeAssistantError),
+    ],
+    ids=["authentication", "parameter", "wyze-api", "connection"],
+)
+async def test_api_failure_does_not_change_optimistic_state(
+    entity: WyzeAirPurifierFan,
+    service: SimpleNamespace,
+    air_purifier: SimpleNamespace,
+    error: Exception,
+    expected_exception: type[HomeAssistantError],
+) -> None:
+    """Failures preserve confirmed state and expose the expected HA error."""
+    service.turn_off.side_effect = error
+
+    with pytest.raises(expected_exception):
+        await entity.async_turn_off()
+
+    assert air_purifier.on is True
+    entity.async_schedule_update_ha_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rejects_unknown_preset(
+    entity: WyzeAirPurifierFan, service: SimpleNamespace
+) -> None:
+    """Unknown presets fail before an API request is made."""
+    with pytest.raises(ValueError, match="Unsupported air purifier preset mode"):
+        await entity.async_set_preset_mode("wind-tunnel")
+
+    service.set_fan_mode.assert_not_awaited()
+
+
+def test_update_callback_dispatches_to_sibling_entities(
+    entity: WyzeAirPurifierFan,
+    air_purifier: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Library callbacks update the fan and notify AQI sensors."""
+    updated = SimpleNamespace(**vars(air_purifier))
+    updated.fan_mode = "turbo"
+    entity.hass = Mock()
+    dispatcher_send = Mock()
+    monkeypatch.setattr(fan_module, "async_dispatcher_send", dispatcher_send)
+
+    entity.async_update_callback(updated)
+
+    assert entity.percentage == 100
+    dispatcher_send.assert_called_once_with(
+        entity.hass,
+        "wyzeapi.air_purifier_updated-AA:BB:CC:DD:EE:FF",
+        updated,
+    )
+    entity.async_schedule_update_ha_state.assert_called_once_with()

--- a/tests/test_air_purifier_sensor.py
+++ b/tests/test_air_purifier_sensor.py
@@ -1,0 +1,106 @@
+"""Tests for Wyze air purifier AQI sensors."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from custom_components.wyzeapi import sensor as sensor_module
+from custom_components.wyzeapi.sensor import (
+    WyzeAirPurifierAQISensor,
+    WyzeAirPurifierHourlyMaxAQISensor,
+)
+
+
+@pytest.fixture
+def air_purifier() -> SimpleNamespace:
+    """Return a representative air purifier with air quality data."""
+    return SimpleNamespace(
+        mac="AA:BB:CC:DD:EE:FF",
+        nickname="Office Purifier",
+        product_model="CO_AP1",
+        available=True,
+        app_version="1.2.3",
+        sn="PURIFIER123",
+        wifi_mac="11:22:33:44:55:66",
+        aqi=42,
+        max_hourly_aqi=55,
+        max_hourly_aqi_start_time=1_700_000_000,
+        max_hourly_aqi_end_time=1_700_001_800,
+    )
+
+
+def test_current_aqi_sensor(air_purifier: SimpleNamespace) -> None:
+    """The current AQI sensor exposes current library data."""
+    sensor = WyzeAirPurifierAQISensor(air_purifier)
+
+    assert sensor.unique_id == "AA:BB:CC:DD:EE:FF-aqi"
+    assert sensor.available is True
+    assert sensor.native_value == 42
+    assert sensor.device_info["identifiers"] == {("wyzeapi", "AA:BB:CC:DD:EE:FF")}
+    assert sensor.extra_state_attributes == {
+        "attribution": "Data provided by Wyze",
+        "device model": "CO_AP1",
+    }
+
+
+def test_hourly_max_aqi_sensor(air_purifier: SimpleNamespace) -> None:
+    """The hourly sensor exposes its value and UTC sample window."""
+    sensor = WyzeAirPurifierHourlyMaxAQISensor(air_purifier)
+
+    assert sensor.unique_id == "AA:BB:CC:DD:EE:FF-hourly-max-aqi"
+    assert sensor.native_value == 55
+    assert sensor.extra_state_attributes == {
+        "attribution": "Data provided by Wyze",
+        "device model": "CO_AP1",
+        "hour_start": "2023-11-14T22:13:20+00:00",
+        "hour_end": "2023-11-14T23:13:20+00:00",
+        "sampled_until": "2023-11-14T22:43:20+00:00",
+    }
+
+
+def test_missing_hourly_timestamps(air_purifier: SimpleNamespace) -> None:
+    """Incomplete AQI responses produce stable null timestamp attributes."""
+    air_purifier.max_hourly_aqi_start_time = None
+    air_purifier.max_hourly_aqi_end_time = None
+    sensor = WyzeAirPurifierHourlyMaxAQISensor(air_purifier)
+
+    assert sensor.extra_state_attributes["hour_start"] is None
+    assert sensor.extra_state_attributes["hour_end"] is None
+    assert sensor.extra_state_attributes["sampled_until"] is None
+
+
+def test_dispatcher_update_replaces_model(air_purifier: SimpleNamespace) -> None:
+    """Dispatcher callbacks replace cached data and write Home Assistant state."""
+    sensor = WyzeAirPurifierAQISensor(air_purifier)
+    sensor.async_write_ha_state = Mock()
+    updated = SimpleNamespace(**vars(air_purifier))
+    updated.aqi = 73
+
+    sensor.handle_air_purifier_update(updated)
+
+    assert sensor.native_value == 73
+    sensor.async_write_ha_state.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_sensor_subscribes_to_air_purifier_dispatcher(
+    air_purifier: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AQI sensors subscribe to fan-owned updates and retain the unsubscribe."""
+    sensor = WyzeAirPurifierAQISensor(air_purifier)
+    sensor.hass = Mock()
+    sensor.async_on_remove = Mock()
+    unsubscribe = Mock()
+    dispatcher_connect = Mock(return_value=unsubscribe)
+    monkeypatch.setattr(sensor_module, "async_dispatcher_connect", dispatcher_connect)
+
+    await sensor.async_added_to_hass()
+
+    dispatcher_connect.assert_called_once_with(
+        sensor.hass,
+        "wyzeapi.air_purifier_updated-AA:BB:CC:DD:EE:FF",
+        sensor.handle_air_purifier_update,
+    )
+    sensor.async_on_remove.assert_called_once_with(unsubscribe)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13.2, <3.14"
 
 [[package]]
@@ -147,6 +147,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiousbwatcher"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asyncinotify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/f9/e33c468d2f04555552bff81ead9657c3f6067628a9a34b126f2e23e0c81a/aiousbwatcher-1.1.1.tar.gz", hash = "sha256:3a22a47b8dd1ca078bf8fbc3139cd16b7dabb11b901a1a96620246794baf679f", size = 6608, upload-time = "2025-01-28T00:11:18.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/57/ecaac367aa57683c4ec4d491e52d3d8148145d17cc983335d84fd0947dc6/aiousbwatcher-1.1.1-py3-none-any.whl", hash = "sha256:2eae01c12dd77f5c8873ef597b48f7872257894ec18b19e6dc3960c33e914aec", size = 4944, upload-time = "2025-01-28T00:11:16.201Z" },
+]
+
+[[package]]
 name = "aiozoneinfo"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -222,6 +234,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
+name = "asyncinotify"
+version = "4.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/90/f04f0a0c2001e43b3b5199ef6c63c117e43e80cdbaab3037b24c57feeef5/asyncinotify-4.4.4.tar.gz", hash = "sha256:a8afc92bec6666807ca50524156fca22655325cba6e2b51d842b8ec0d399c708", size = 20868, upload-time = "2026-04-13T20:32:27.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/31/0ac34c340f517a06cf944c2b4a518c53addf5663df7c704ee711b5e5c662/asyncinotify-4.4.4-py3-none-any.whl", hash = "sha256:9f4236249d78af4451eb689d0c1ed1f52ab5d44a22c7dd699f3dd34f2c3e01f4", size = 20225, upload-time = "2026-04-13T20:32:26.184Z" },
 ]
 
 [[package]]
@@ -546,6 +567,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "cronsim"
 version = "2.7"
 source = { registry = "https://pypi.org/simple" }
@@ -696,9 +726,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/3c/bb37b9d40d65b0741a8b040ca5c307034d0a9822994dff5f825c88dd7a6b/greenlet-3.5.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:0629377725977252159de1ebd3c6e49c170a63856e585446797bb3d66d4d9c34", size = 287178, upload-time = "2026-06-17T17:35:25.132Z" },
     { url = "https://files.pythonhosted.org/packages/f0/a6/0c5902393f492f8ceb19d0b5cf139284e3a11b333a049739643b1036b6f8/greenlet-3.5.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2ddf9eddc617681108dd071b3feabf3f4a4cd64846254aec4d4ceda098b639a", size = 606900, upload-time = "2026-06-17T18:07:21.692Z" },
     { url = "https://files.pythonhosted.org/packages/d8/7c/42899c31d4b87148ae4e3f87f63e13398824be6241f4dde42ded95768a34/greenlet-3.5.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f41feb9f2b59e2e61ac9bea4e344ddd9396bf3cacb2583f73a3595ed7df6f8e7", size = 619265, upload-time = "2026-06-17T18:29:44.837Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/7e/28f991affb413b232b1e7d768db24c37b3f4d5daecc3f19b455d40bd2dea/greenlet-3.5.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9dc23f0e5ad76415457212a4b947d22ebe4dc80baf02adf7dd5647a90f38bb4e", size = 625044, upload-time = "2026-06-17T18:39:29.046Z" },
     { url = "https://files.pythonhosted.org/packages/d3/52/4ff8c98d3cfe62b4515f8584ae14510a58f35c549cc5292b78d9b7a40b70/greenlet-3.5.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09201fa698768db245920b00fdc86ee3e73540f01ca6db162be9632642e1a473", size = 616187, upload-time = "2026-06-17T17:39:29.473Z" },
-    { url = "https://files.pythonhosted.org/packages/29/05/0cc9ec660e7acff85f93b0a048b6654371c822c884add44c02a465cf70e0/greenlet-3.5.2-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:423167363c510a75b649f5cd58d873c29498ea03598b9e4b1c3b73e0f899f3d5", size = 427322, upload-time = "2026-06-17T18:41:20.892Z" },
     { url = "https://files.pythonhosted.org/packages/c9/a6/269c8bf9aefc13361ce1088f0e392b154cb21005de7862e42b5d782b81fd/greenlet-3.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a1759fa4f14c398508cf20dc8037de55cc23ae8bd14c185c2718257837195ca5", size = 1573778, upload-time = "2026-06-17T18:22:13.497Z" },
     { url = "https://files.pythonhosted.org/packages/1f/9b/391d015cbc6323e81b14c02cf825fdca7e0049c9bb489bf4ac72883118ba/greenlet-3.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9318cdeb9abdbfdd8bc8464ee4a06dffde2c7846e1def138365a6240ab2c9a5", size = 1638092, upload-time = "2026-06-17T17:40:08.163Z" },
     { url = "https://files.pythonhosted.org/packages/49/53/5b4df711f4356c62e85d9f819d87966d526d1cfb32bae49a8f7d6fc36ea4/greenlet-3.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:2c3b3311af72b3d3b03cc0f1ffd11f072e834be5d0444105cf715fc44434e39c", size = 239352, upload-time = "2026-06-17T17:38:51.593Z" },
@@ -747,6 +775,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiousbwatcher" },
+    { name = "pyserial" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -758,7 +790,13 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.12.1" }]
+dev = [
+    { name = "aiousbwatcher", specifier = "==1.1.1" },
+    { name = "pyserial", specifier = "==3.5" },
+    { name = "pytest", specifier = ">=8.0.0,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0,<2.0.0" },
+    { name = "ruff", specifier = ">=0.12.1" },
+]
 
 [[package]]
 name = "habluetooth"
@@ -941,6 +979,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1135,6 +1182,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1285,6 +1341,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1375,6 +1440,43 @@ name = "pyric"
 version = "0.1.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c7bfc0aa516016c46dc4c0f380ffccbd742a61af1eda/PyRIC-0.1.6.3.tar.gz", hash = "sha256:b539b01cafebd2406c00097f94525ea0f8ecd1dd92f7731f43eac0ef16c2ccc9", size = 870401, upload-time = "2016-12-04T07:54:48.374Z" }
+
+[[package]]
+name = "pyserial"
+version = "3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
 
 [[package]]
 name = "python-dateutil"


### PR DESCRIPTION
## Summary
- Add focused automated coverage for the merged Wyze air purifier fan and AQI sensor entities.
- Cover platform setup, updater registration/removal, callback assignment, manager startup, dispatcher subscription, optimistic state, and authentication/API/connection failures.
- Let `AccessTokenError` reach the existing token exception handler so Home Assistant raises `ConfigEntryAuthFailed`.
- Add test-only development dependencies and REUSE coverage for the new tests and lockfile.

## Why
PR #853 added the purifier entities without automated regression coverage. Its fan command methods also caught `AccessTokenError` before the token exception decorator, which converted authentication failures into generic `HomeAssistantError` responses.

## Validation
- `uv sync --locked`
- `uv run pytest` — 17 passed
- `uv run ruff check custom_components/wyzeapi tests`
- `uv run ruff format --check custom_components/wyzeapi tests`
- `uv lock --check`
- `uvx reuse lint`

The pytest GitHub Actions workflow is intentionally deferred to a separate follow-up PR. Broader clean-environment import/dependency architecture is also out of scope here.