### PR TITLE
Run pytest in GitHub Actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,33 @@
+name: Pytest
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: Pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow for the pytest suite.
- Install Python and uv with pinned actions.
- Run `uv sync --locked` followed by `uv run pytest` on pushes and pull requests targeting `master`.

## Why
The purifier tests now live in the repository, but regressions were not covered by CI. This follow-up adds the requested automated test gate without changing application code.

## Validation
- `uv sync --locked`
- `uv run pytest` — 17 passed
- `uv run ruff check custom_components/wyzeapi tests`
- `uv run ruff format --check custom_components/wyzeapi tests`
- `uv lock --check`
- `uvx reuse lint`