### PR TITLE
chore(release): bump version to 0.1.39

### DIFF
--- a/custom_components/wyzeapi/manifest.json
+++ b/custom_components/wyzeapi/manifest.json
@@ -14,5 +14,5 @@
     "wyzeapy>=0.6.1,<0.7",
     "websockets"
   ],
-  "version": "0.1.38"
+  "version": "0.1.39"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "ha-wyzeapi"
-version = "0.1.38"
+version = "0.1.39"
 description = "A Home Assistant integration for Wyze devices"
 authors = [{ name = "Katie Mulliken", email = "katie@mulliken.net" }]
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "ha-wyzeapi"
-version = "0.1.38"
+version = "0.1.39"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
## Summary

- bump the integration and package metadata from 0.1.38 to 0.1.39
- regenerate `uv.lock` so its root package metadata matches
- prepare the next release after the merged air purifier support and CI improvements

Release notes will be generated automatically when the GitHub release is published.

## Validation

- `uv sync --locked`
- `uv run pytest` — 17 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`