### PR TITLE
feat(bolt): read the Lock Bolt battery live over BLE instead of a cloud sensor nothing polls

### DIFF
--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -25,5 +25,9 @@ DEFAULT_LOCAL_CONTROL = True
 
 # Yunding (YD) is the provider for Wyze Lock Bolt
 YDBLE_LOCK_STATE_UUID = "00002220-0000-6b63-6f6c-2e6b636f6f6c"
+# Standard BLE Battery Level UUID, but the Bolt does not follow the spec here: instead of
+# a one-byte percentage it returns a 16-byte AES-128-ECB block using the same key as the
+# lock state characteristic above. Reading byte 0 raw yields garbage. See ydble_utils.
+YDBLE_BATTERY_LEVEL_UUID = "00002a19-0000-1000-8000-00805f9b34fb"
 YDBLE_UART_RX_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
 YDBLE_UART_TX_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"

--- a/custom_components/wyzeapi/coordinator.py
+++ b/custom_components/wyzeapi/coordinator.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from typing import Dict
 
 from bleak import BleakClient
-from bleak.exc import BleakCharacteristicNotFoundError
+from bleak.exc import BleakCharacteristicNotFoundError, BleakError
 from bleak_retry_connector import establish_connection
 
 from homeassistant.components import bluetooth
@@ -14,13 +14,19 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from wyzeapy.services.lock_service import LockService, Lock
 
-from .const import YDBLE_LOCK_STATE_UUID, YDBLE_UART_RX_UUID, YDBLE_UART_TX_UUID
+from .const import (
+    YDBLE_BATTERY_LEVEL_UUID,
+    YDBLE_LOCK_STATE_UUID,
+    YDBLE_UART_RX_UUID,
+    YDBLE_UART_TX_UUID,
+)
 from .token_manager import token_exception_handler
 from .ydble_utils import (
     decrypt_ecb,
     pack_l1,
     pack_l2_dict,
     pack_l2_lock_unlock,
+    parse_battery_block,
     parse_l1,
     parse_l2_dict,
 )
@@ -50,7 +56,7 @@ class WyzeLockBoltCoordinator(DataUpdateCoordinator):
         self._bleak_client = None
         self._current_command = None
         # Initialize data to prevent errors during setup
-        self.data = {"state": None, "timestamp": None}
+        self.data = {"state": None, "timestamp": None, "battery": None}
 
     @token_exception_handler
     async def update_lock_info(self):
@@ -73,7 +79,11 @@ class WyzeLockBoltCoordinator(DataUpdateCoordinator):
 
         try:
             value = await client.read_gatt_char(YDBLE_LOCK_STATE_UUID)
-            return self._parse_state(value)
+            state = self._parse_state(value)
+            # Reuses the connection we already have open, so this costs no extra
+            # BLE connect and does not wake the lock a second time.
+            state["battery"] = await self._read_battery(client)
+            return state
         except BleakCharacteristicNotFoundError as e:
             raise UpdateFailed(
                 f"Characteristic {YDBLE_LOCK_STATE_UUID} not found on device {self._lock.nickname}. "
@@ -81,6 +91,30 @@ class WyzeLockBoltCoordinator(DataUpdateCoordinator):
             ) from e
         finally:
             await self._disconnect()
+
+    async def _read_battery(self, client: BleakClient):
+        """Read the battery percentage over BLE.
+
+        Returns the previous reading on any failure so a bad battery read never fails
+        the whole refresh and takes the lock entity down with it.
+        """
+        previous = self.data.get("battery") if self.data else None
+        try:
+            raw = await client.read_gatt_char(YDBLE_BATTERY_LEVEL_UUID)
+        except (BleakError, TimeoutError, OSError) as err:
+            _LOGGER.debug("Could not read battery for %s: %s", self._lock.nickname, err)
+            return previous
+
+        percent = parse_battery_block(self._uuid[-16:].lower(), raw)
+        if percent is None:
+            _LOGGER.debug(
+                "Battery block for %s did not validate (raw %s); keeping %s",
+                self._lock.nickname,
+                binascii.hexlify(bytes(raw)),
+                previous,
+            )
+            return previous
+        return percent
 
     async def lock_unlock(self, command="lock"):
         if self._current_command:
@@ -123,7 +157,11 @@ class WyzeLockBoltCoordinator(DataUpdateCoordinator):
         await client.write_gatt_char(YDBLE_UART_TX_UUID, req, response=False)
 
     async def _handle_state(self, sender, data: bytearray):
-        self.data = self._parse_state(data)
+        state = self._parse_state(data)
+        # A state notification carries no battery reading, so carry the last one
+        # forward rather than blanking the battery sensor on every lock/unlock.
+        state["battery"] = self.data.get("battery") if self.data else None
+        self.data = state
         self._current_command = None
         self.async_update_listeners()
 

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.event import (
     async_track_state_change_event,
     async_track_time_change,
 )
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     AIR_PURIFIER_UPDATED,
@@ -77,7 +78,22 @@ async def async_setup_entry(
 
     locks = await lock_service.get_locks()
     sensors = []
+    coordinators = hass.data[DOMAIN][config_entry.entry_id].get("coordinators", {})
+    bolt_sensors = []
     for lock in locks:
+        if lock.product_model == "YD_BT1":
+            # The cloud battery sensor is inert for a Bolt. It becomes available only
+            # via the LOCK_UPDATED dispatch, which is sent by WyzeLock, and no WyzeLock
+            # is created for YD_BT1, so nothing registers the lock with the update
+            # manager and `_available` stays False for the entity's whole life.
+            # The cloud does hold a battery value, but only in the _get_lock_info
+            # payload that dispatch would have fetched, and it is only as fresh as the
+            # last time a phone synced the lock over Bluetooth (see `power_refreshtime`).
+            # Read it over BLE instead, where it is live and needs no cloud round trip.
+            coordinator = coordinators.get(lock.mac)
+            if coordinator is not None:
+                bolt_sensors.append(WyzeLockBoltBatterySensor(coordinator))
+            continue
         sensors.append(WyzeLockBatterySensor(lock, WyzeLockBatterySensor.LOCK_BATTERY))
         sensors.append(
             WyzeLockBatterySensor(lock, WyzeLockBatterySensor.KEYPAD_BATTERY)
@@ -119,6 +135,46 @@ async def async_setup_entry(
         )
 
     async_add_entities(sensors, True)
+    # Coordinator-backed; must not update before add or setup waits on a BLE connect.
+    if bolt_sensors:
+        async_add_entities(bolt_sensors, False)
+
+
+class WyzeLockBoltBatterySensor(CoordinatorEntity, SensorEntity):
+    """Battery for a Wyze Lock Bolt, read over BLE by the coordinator."""
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
+    _attr_name = "Battery"
+
+    def __init__(self, coordinator) -> None:
+        super().__init__(coordinator)
+        self._lock = coordinator._lock
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._lock.mac}.ble_battery"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        # Match WyzeLockBolt so this lands on the existing lock device.
+        return {
+            "identifiers": {(DOMAIN, self._lock.mac)},
+            "name": self._lock.nickname,
+        }
+
+    @property
+    def native_value(self):
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("battery")
+
+    @property
+    def available(self) -> bool:
+        return super().available and self.native_value is not None
 
 
 class WyzeLockBatterySensor(SensorEntity):

--- a/custom_components/wyzeapi/ydble_utils.py
+++ b/custom_components/wyzeapi/ydble_utils.py
@@ -18,6 +18,28 @@ def encrypt_ecb(key: str, data: bytes) -> bytes:
     return encrypted_data
 
 
+def parse_battery_block(key: str, data: bytes) -> int | None:
+    """Decode the Lock Bolt's battery characteristic (0x2A19).
+
+    Unlike a standard BLE Battery Level, the Bolt returns a 16-byte AES-128-ECB block
+    encrypted with the same key as the lock state characteristic. The decrypted layout
+    matches the status block: byte 0 is the percentage and bytes 11:16 carry the ASCII
+    marker "loock", which is absent if the key is wrong.
+
+    Returns the percentage, or None if the block does not validate.
+    """
+    try:
+        decrypted = decrypt_ecb(key, data)
+    except (ValueError, KeyError):
+        return None
+    if len(decrypted) < 16 or decrypted[11:16] != b"loock":
+        return None
+    percent = decrypted[0]
+    if not 0 < percent <= 100:
+        return None
+    return percent
+
+
 def pack_l1(flags: int, seq_no: int, data: bytes):
     data_crc = crc(data)
     result = b"\xab"

--- a/tests/test_bolt_battery.py
+++ b/tests/test_bolt_battery.py
@@ -1,0 +1,171 @@
+"""Tests for the Wyze Lock Bolt battery block decoder.
+
+The Bolt's 0x2A19 characteristic is not a standard one-byte BLE Battery Level. It
+returns a 16-byte AES-128-ECB block encrypted with the same key used for the lock
+state characteristic. Layout of the decrypted block, per the Wyze app's own decode
+(``C21643f.java`` battery callback plus ``C21552t.m67888k``):
+
+    byte 0      battery percentage, valid range 1..100
+    bytes 11:16 ASCII marker "loock"
+
+These tests build blocks with the real cipher and assert the decoder recovers the
+expected values, so they fail if the layout or validation is ever broken.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bleak.exc import BleakError
+import pytest
+
+from custom_components.wyzeapi.ydble_utils import encrypt_ecb, parse_battery_block
+
+LOCK_UUID = "YD_BT1.b38ae5ebd9864864273db2c08fab2c28"
+
+# 16 chars, matching the lock UUID's trailing 16 used as the AES key.
+KEY = "273db2c08fab2c28"
+
+
+def _block(percent: int, marker: bytes = b"loock", pad: bytes = b"\x00" * 6) -> bytes:
+    """Build a plaintext status block, then encrypt it the way the lock would."""
+    plaintext = bytes([percent]) + b"\x00" * 4 + pad[:6] + marker
+    assert len(plaintext) == 16, f"block must be one AES block, got {len(plaintext)}"
+    return encrypt_ecb(KEY, plaintext)
+
+
+def test_decodes_reported_percentage():
+    """98% is what the Wyze app showed for this lock, so use it as the worked example."""
+    assert parse_battery_block(KEY, _block(98)) == 98
+
+
+def test_decodes_boundary_values():
+    assert parse_battery_block(KEY, _block(1)) == 1
+    assert parse_battery_block(KEY, _block(100)) == 100
+
+
+def test_rejects_zero_and_out_of_range():
+    """The app treats 0 and >100 as invalid rather than reporting a bogus level."""
+    assert parse_battery_block(KEY, _block(0)) is None
+    assert parse_battery_block(KEY, _block(101)) is None
+    assert parse_battery_block(KEY, _block(255)) is None
+
+
+def test_rejects_wrong_marker():
+    """A wrong key decrypts to noise; the marker is what catches it."""
+    assert parse_battery_block(KEY, _block(50, marker=b"xxxxx")) is None
+
+
+def test_rejects_wrong_key():
+    """Decrypting with a different key must not yield a plausible percentage."""
+    other = "ffffffffffffffff"
+    assert parse_battery_block(other, _block(98)) is None
+
+
+def test_rejects_short_block():
+    """A standard one-byte Battery Level read must not be misread as a status block."""
+    assert parse_battery_block(KEY, b"\x62") is None
+
+
+def test_ignores_padding_contents():
+    """Only byte 0 and the marker are load-bearing; padding must not affect decoding."""
+    assert parse_battery_block(KEY, _block(77, pad=b"\x01\x02\x03\x04\x05\x06")) == 77
+
+
+# --------------------------------------------------------------------------------------
+# The rest of the change: where the reading is stored, and what it must not disturb.
+# --------------------------------------------------------------------------------------
+
+
+def make_coordinator():
+    lock = MagicMock()
+    lock.mac = LOCK_UUID
+    lock.nickname = "Test Bolt"
+
+    with patch("homeassistant.helpers.frame.report_usage"):
+        from custom_components.wyzeapi.coordinator import WyzeLockBoltCoordinator
+
+        coordinator = WyzeLockBoltCoordinator(MagicMock(), MagicMock(), lock)
+
+    coordinator.async_update_listeners = MagicMock()
+    return coordinator
+
+
+def test_ble_unique_id_cannot_collide_with_the_cloud_sensor():
+    """The new entity must not adopt or clash with the cloud sensor's registry key.
+
+    Guards the claim that this change needs no registry migration. The two schemes are
+    unrelated: the cloud sensor keys on the nickname, this one on the MAC.
+    """
+    from custom_components.wyzeapi.sensor import (
+        WyzeLockBoltBatterySensor,
+        WyzeLockBatterySensor,
+    )
+
+    lock = MagicMock()
+    lock.mac = LOCK_UUID
+    lock.nickname = "Test Bolt"
+
+    coordinator = make_coordinator()
+    ble_id = WyzeLockBoltBatterySensor(coordinator).unique_id
+
+    cloud_ids = {
+        WyzeLockBatterySensor(lock, WyzeLockBatterySensor.LOCK_BATTERY).unique_id,
+        WyzeLockBatterySensor(lock, WyzeLockBatterySensor.KEYPAD_BATTERY).unique_id,
+    }
+
+    assert ble_id not in cloud_ids
+    assert ble_id == f"{LOCK_UUID}.ble_battery"
+
+
+def test_ble_sensor_attaches_to_the_existing_lock_device():
+    """A mismatched identifier would create a second device for the same lock."""
+    from custom_components.wyzeapi.lock import WyzeLockBolt
+    from custom_components.wyzeapi.sensor import WyzeLockBoltBatterySensor
+
+    coordinator = make_coordinator()
+    coordinator._mac = "28:68:47:E9:D0:7B"
+    coordinator._lock.raw_dict = {"hardware_info": {"sn": "SN123"}}
+
+    sensor_ids = WyzeLockBoltBatterySensor(coordinator).device_info["identifiers"]
+    lock_ids = WyzeLockBolt(coordinator).device_info["identifiers"]
+
+    assert sensor_ids == lock_ids
+
+
+@pytest.mark.asyncio
+async def test_state_notification_does_not_blank_the_battery():
+    """Lock and unlock notifications carry no battery, so the last value must persist.
+
+    Without the carry-forward the sensor drops to unknown on every command.
+    """
+    coordinator = make_coordinator()
+    coordinator.data = {"state": 0, "timestamp": None, "battery": 98}
+
+    block = encrypt_ecb(LOCK_UUID[-16:].lower(), bytes([1, 0, 0, 0, 0]) + b"\x00" * 11)
+    await coordinator._handle_state(None, bytearray(block))
+
+    assert coordinator.data["state"] == 1, "the new state must still be applied"
+    assert coordinator.data["battery"] == 98
+
+
+@pytest.mark.asyncio
+async def test_a_failed_battery_read_keeps_the_previous_value():
+    """A flaky battery read must never take the lock entity down with it."""
+    coordinator = make_coordinator()
+    coordinator.data = {"state": 1, "timestamp": None, "battery": 98}
+
+    client = MagicMock()
+    client.read_gatt_char = AsyncMock(side_effect=BleakError("read failed"))
+
+    assert await coordinator._read_battery(client) == 98
+
+
+@pytest.mark.asyncio
+async def test_an_undecodable_battery_block_keeps_the_previous_value():
+    """A block that fails the marker check must not publish a garbage percentage."""
+    coordinator = make_coordinator()
+    coordinator.data = {"state": 1, "timestamp": None, "battery": 98}
+
+    client = MagicMock()
+    client.read_gatt_char = AsyncMock(return_value=bytearray(b"\x00" * 16))
+
+    assert await coordinator._read_battery(client) == 98


### PR DESCRIPTION
## Summary

- Add a battery sensor for the Lock Bolt, read over BLE on the poll that already fetches lock state, so it costs no extra connect.
- Stop creating the cloud battery sensors for `YD_BT1`, which are permanently `unavailable`.
- No change to any other lock model.
- 29 tests; each fix mutation-checked by reverting it and confirming the right test fails.

Fixes #833, which the stale bot closed without a fix. tpawley2001 described the same decode in a comment there on July 24 and offered to open a PR; this work is independent of that comment, and their write-up agrees on the key, the layout and the marker.

Independent of #897, the other open Bolt fix from this investigation, which covers command reliability. Both branch off `master` and either can merge first. Whichever lands second conflicts only in `coordinator.py`'s import block, and I will rebase it the same day. A third change covering poll resilience is written and tested but held back, because it overlaps this one inside `_async_update_data` and is better rebased onto whatever lands here than reviewed alongside it.

## Root cause

`sensor.py` creates the same cloud-backed battery sensors for a Bolt as for the Wi-Fi and gateway locks, and they never work, for one reason with two symptoms. `WyzeLockBatterySensor` becomes available only via the `LOCK_UPDATED-{mac}` dispatch, and its `raw_dict` is whatever lock that dispatch hands it. Both depend on the lock being registered with the update manager in `WyzeLock.async_added_to_hass` (`lock.py:211`), and no `WyzeLock` is created for a `YD_BT1` (`lock.py:58`); the Bolt gets `WyzeLockBolt`, which never registers and never dispatches. So `_available` stays `False` for the entity's whole life, *and* it never receives a `raw_dict` containing `power`.

The battery is genuinely in the cloud, but only in the payload dispatch would have fetched. Checked against my own lock with the account's token:

| payload | `power` |
|---------|---------|
| `get_locks()`, the device list used at setup | key absent |
| `LockService.update()`, i.e. `_get_lock_info` | `98`, plus `power_refreshtime` |

It is also only as fresh as the last phone sync, since the Bolt has no network radio: opening the Wyze app moved `power_refreshtime` to 69 seconds prior. Registering the Bolt with the update manager would light up the existing entity instead, but I prefer BLE, because it is live rather than sync-dependent, needs no cloud round trip, and costs nothing extra on a connection the coordinator already opens.

## Fix

The Bolt exposes the standard Battery Level UUID `00002a19-...` but does not follow the spec. Instead of a one-byte percentage it returns a 16-byte AES-128-ECB block, keyed the same as lock state and with the same layout: byte 0 is the percentage, bytes 11:16 carry the ASCII marker `loock`. Reading byte 0 raw yields garbage.

The new `parse_battery_block` decrypts, then requires at least 16 bytes, the `loock` marker in place, and a percentage in 1 to 100, returning `None` if any of those fail. That marker check is what makes it safe: a wrong key or short read fails validation rather than producing a plausible-looking wrong percentage.

The read reuses the connection `_async_update_data` already opens, and a failure returns the previous value instead of failing the refresh, so a bad battery read never takes the lock entity down. State notifications carry no battery, so the state handler carries the last value forward instead of blanking the sensor on every command.

## Why existing installs are undisturbed

- The skip is keyed on `product_model == "YD_BT1"` only. `WLCK1` and gateway locks take exactly the path they take today, keypad sensors included.
- The new `unique_id` is the MAC plus `.ble_battery`, while the cloud sensors key off the nickname plus the battery type, so the schemes cannot collide and the registry migrates nothing. A test asserts this, since the no-migration argument rests on it.
- `device_info` uses the same MAC identifier as `WyzeLockBolt`, so the sensor lands on the existing lock device rather than a second one.
- One behaviour change: existing Bolt owners' two permanently-`unavailable` battery entities stop being created and become orphaned registry entries they can delete. Those have only ever reported `unavailable`, so no dashboard or automation can depend on a number from one.

## Verification

Real `YD_BT1` behind an ESPHome proxy.

- Sensor reports 98%, matching the Wyze app for the same lock, and survives lock and unlock rather than dropping to `unknown`. The cloud `power` in the table above is the same 98, which independently confirms the decoder.
- Confirmed in the entity registry that the old cloud entities use the nickname scheme and that the new sensor registered cleanly without taking over either ID.

Seven of the 29 tests cover the decoder using blocks built with the real cipher; five cover the unique_id and device-identifier claims above, the battery surviving a state notification, and a failed or undecodable read keeping the previous value. The `YD_BT1` branch in `async_setup_entry` has no unit test, since exercising it needs config-entry and service scaffolding this suite lacks; verified on hardware instead.

## Environment

- HA Version: 2026.7.4
- WyzeApi Version: 0.1.38
- Install: HAOS
- Device: Wyze Lock Bolt (`YD_BT1`) via an ESPHome Bluetooth proxy

## Validation
- `uv run --locked ruff check custom_components/wyzeapi`
- `uv run --locked ruff format --check custom_components/wyzeapi`
- `uv run pytest`
- live tested on a `YD_BT1` through an ESPHome Bluetooth proxy: battery reports 98%, matching both the Wyze app and the cloud `power` field
