### PR TITLE
fix: remove stale switch entities by entity_id

### DIFF
--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -194,7 +194,7 @@ async def async_migrate_switch_data(
                             "automation": issue,
                         },
                     )
-            entity_registry.async_remove(entity.id)
+            entity_registry.async_remove(entity.entity_id)
 
     for device in device_list:
         device_automations = automations_with_device(hass, device)


### PR DESCRIPTION
`async_remove()` expects an entity_id. `entity.id` is the registry row id, so the call raises KeyError and takes the whole switch platform down with it. On my account that was all 52 switches gone, not just the stale one.
