### PR TITLE
fix: handle cameras that report no motion or notification property

### DIFF
--- a/custom_components/wyzeapi/switch.py
+++ b/custom_components/wyzeapi/switch.py
@@ -536,7 +536,7 @@ class WyzeCameraNotificationSwitch(SwitchEntity):
     @property
     def is_on(self):
         """Return true if switch is on."""
-        return self._device.notify
+        return getattr(self._device, "notify", None)
 
     @property
     def unique_id(self):
@@ -622,7 +622,7 @@ class WyzeCameraMotionSwitch(SwitchEntity):
     @property
     def is_on(self):
         """Return true if switch is on."""
-        return self._device.motion
+        return getattr(self._device, "motion", None)
 
     @property
     def unique_id(self):


### PR DESCRIPTION
`Camera.__init__` defaults `on`, `siren`, `floodlight` and `garage`, but not `motion` or `notify`. `CameraService.update` only sets those two when the model's property list carries `MOTION_DETECTION` or `NOTIFICATION`.

My video doorbell (`GW_DBD`) reports neither. Every state write raised AttributeError on a 45 second loop, and both switches sat unavailable indefinitely while the rest of the integration updated normally.

Reading them through `getattr` with a None default leaves an unsupported camera showing `unknown` instead of a fabricated `off`. The deeper fix is two more defaults in `Camera.__init__` in wyzeapy, if you would rather take it there instead.
