### PR TITLE
fix: strip H.264 packetization mode 0 from the offer

### DIFF
--- a/custom_components/wyzeapi/camera.py
+++ b/custom_components/wyzeapi/camera.py
@@ -45,6 +45,45 @@ FALLBACK_ICE_SERVERS = [
 ]
 
 
+def strip_h264_mode0(sdp: str) -> str:
+    """Remove H.264 payload types that use packetization-mode=0 from an offer.
+
+    Battery cameras pick the mode-0 payload type when the browser offers one,
+    then send FU-A fragmented NAL units anyway. The browser's mode-0
+    depacketiser drops those, so the stream arrives and nothing decodes:
+    measured 1,757,262 bytes over 1,626 packets for framesDecoded=1, against
+    189 frames from a camera that answered mode 1. Offering only mode 1 leaves
+    the camera the payload type the browser can actually depacketise, at the
+    same profile.
+    """
+    mode0 = set()
+    for match in re.finditer(r"a=fmtp:(\d+) ([^\r\n]*packetization-mode=0[^\r\n]*)", sdp):
+        mode0.add(match.group(1))
+    if not mode0:
+        return sdp
+
+    # An rtx payload type is only useful while the type it repairs survives.
+    for match in re.finditer(r"a=fmtp:(\d+) apt=(\d+)", sdp):
+        if match.group(2) in mode0:
+            mode0.add(match.group(1))
+
+    kept_lines = []
+    for line in sdp.splitlines(keepends=True):
+        stripped = line.rstrip("\r\n")
+        if stripped.startswith("m=video "):
+            parts = stripped.split(" ")
+            head, payloads = parts[:3], parts[3:]
+            line = " ".join(head + [p for p in payloads if p not in mode0]) + "\r\n"
+        else:
+            match = re.match(r"a=(?:rtpmap|fmtp|rtcp-fb):(\d+)[ :]", stripped)
+            if match and match.group(1) in mode0:
+                continue
+        kept_lines.append(line)
+
+    _LOGGER.debug("Stripped packetization-mode=0 payload types %s", sorted(mode0))
+    return "".join(kept_lines)
+
+
 @token_exception_handler
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -290,6 +329,8 @@ class WyzeCamera(CameraEntity):
         # runs the iot-device wakeup action before sending its offer.
         # The config is always fetched fresh here: KVS signed URLs are
         # single-use and short-lived.
+        offer_sdp = strip_h264_mode0(offer_sdp)
+
         config = await self.wake_and_fetch_config()
         _LOGGER.debug("Fresh config for offer on camera %s: %s", self.name, config)
 
@@ -511,6 +552,7 @@ class WyzeCameraWebRTCSession:
         An offer of recvonly must be answered with sendonly or inactive.
         """
         _LOGGER.debug("Attempt to fix sdp answer...")
+
         if isinstance(self.sdp_answer, str) and isinstance(self.sdp_offer, str):
             sdp_kinds = ["audio", "video", "application"]
             sdp_directions = ["sendrecv", "sendonly", "recvonly", "inactive"]

--- a/custom_components/wyzeapi/camera.py
+++ b/custom_components/wyzeapi/camera.py
@@ -34,6 +34,16 @@ from .token_manager import token_exception_handler
 
 _LOGGER = logging.getLogger(__name__)
 
+# Used only when a camera has no cached session config yet: the client-config
+# hook is synchronous and cannot fetch one. Public STUN is enough to gather
+# host and server-reflexive candidates; the offer that follows carries the
+# camera's own KVS TURN servers.
+FALLBACK_ICE_SERVERS = [
+    {"url": "stun:stun.kinesisvideo.us-west-2.amazonaws.com:443", "username": "", "credential": ""},
+    {"url": "stun:stun.l.google.com:19302", "username": "", "credential": ""},
+    {"url": "stun:stun1.l.google.com:19302", "username": "", "credential": ""},
+]
+
 
 @token_exception_handler
 async def async_setup_entry(
@@ -106,6 +116,52 @@ class WyzeCamera(CameraEntity):
             "Initial fetch of WebRTC session configuration complete for camera %s",
             self.name,
         )
+
+    async def wake_and_fetch_config(self) -> dict:
+        """Wake the camera if it sleeps, then fetch a fresh stream config.
+
+        A battery camera reports iot-state 0 until it has finished waking, so
+        the first get_stream_info after the wakeup action still answers
+        "offline". Poll for it instead of failing the whole request on the
+        first no.
+        """
+        battery = self._camera.product_model in DEVICEMGMT_API_MODELS
+        if battery:
+            try:
+                await self._camera_service.turn_on(self._camera)
+                _LOGGER.debug("Sent wakeup for camera %s", self.name)
+            except Exception as err:
+                _LOGGER.warning("Wakeup failed for camera %s: %s", self.name, err)
+
+        attempts = 6 if battery else 1
+        last_err: Exception | None = None
+        for attempt in range(attempts):
+            try:
+                config = await self._camera_service.get_stream_info(self._camera)
+            except Exception as err:
+                last_err = err
+                _LOGGER.debug(
+                    "Stream config attempt %d/%d failed for camera %s: %s",
+                    attempt + 1,
+                    attempts,
+                    self.name,
+                    err,
+                )
+                if attempt + 1 < attempts:
+                    await asyncio.sleep(4)
+                continue
+            self._cached_config = config
+            return config
+        raise HomeAssistantError(
+            f"Camera {self.name} did not come online for streaming: {last_err}"
+        )
+
+    async def background_config_refresh(self) -> None:
+        """Populate the config cache out of band so the next view has real ICE servers."""
+        try:
+            await self.wake_and_fetch_config()
+        except Exception as err:
+            _LOGGER.debug("Background config refresh failed for camera %s: %s", self.name, err)
 
     @cached_property
     def device_info(self) -> DeviceInfo | None:
@@ -183,11 +239,21 @@ class WyzeCamera(CameraEntity):
 
     def _async_get_webrtc_client_configuration(self) -> WebRTCClientConfiguration:
         """Return the WebRTC client configuration for this camera, including ICE servers."""
-        # This shouldn't happen, but throw an error if we don't have a config ready yet
-        if self._cached_config is None:
-            raise HomeAssistantError("WebRTC session configuration not available yet")
-
+        # A camera that was asleep when the integration set up has no cached
+        # config, and this hook is synchronous so it cannot fetch one. Raising
+        # here failed the view before the offer, which is what does the
+        # wakeup, ever ran. Fall back to public STUN and refresh out of band.
         config = self._cached_config
+        if config is None:
+            _LOGGER.debug(
+                "No cached WebRTC config for camera %s, using STUN-only fallback",
+                self.name,
+            )
+            if self._config_task is None or self._config_task.done():
+                self._config_task = self.hass.async_create_task(
+                    self.background_config_refresh()
+                )
+            config = {"ice_servers": FALLBACK_ICE_SERVERS}
 
         ice_servers = []
         for server in config.get("ice_servers", []):
@@ -222,19 +288,9 @@ class WyzeCamera(CameraEntity):
         # channel; without this the offer goes to a channel with no master
         # and no answer ever arrives. Mirrors the my.wyze.com client, which
         # runs the iot-device wakeup action before sending its offer.
-        if self._camera.product_model in DEVICEMGMT_API_MODELS:
-            try:
-                await self._camera_service.turn_on(self._camera)
-                _LOGGER.debug("Sent wakeup for camera %s", self.name)
-            except Exception as err:
-                _LOGGER.warning("Wakeup failed for camera %s: %s", self.name, err)
-
-        # Always fetch a truly fresh config so the signaling URL and ICE servers
-        # are never stale — KVS signed URLs are single-use and short-lived.
-        config = await self._camera_service.get_stream_info(self._camera)
-
-        # Update cached config with the new ICE servers
-        self._cached_config = config
+        # The config is always fetched fresh here: KVS signed URLs are
+        # single-use and short-lived.
+        config = await self.wake_and_fetch_config()
         _LOGGER.debug("Fresh config for offer on camera %s: %s", self.name, config)
 
         self.sessions[session_id] = WyzeCameraWebRTCSession(
@@ -404,7 +460,7 @@ class WyzeCameraWebRTCSession:
     async def send_candidate(self, candidate: RTCIceCandidateInit):
         """Send an ICE candidate to the Kinesis Video Streams signaling channel."""
         # Take RTCIceCandidateInit, convert it to the format in the messagePayload above, and send it to the client using the callback
-        # Wait for send_offer to establish the connection — never reconnect (KVS URLs are single-use)
+        # Wait for send_offer to establish the connection, never reconnect (KVS URLs are single-use)
         try:
             await asyncio.wait_for(self._connected.wait(), timeout=10.0)
         except asyncio.TimeoutError as exc:

--- a/custom_components/wyzeapi/camera.py
+++ b/custom_components/wyzeapi/camera.py
@@ -27,7 +27,7 @@ from propcache.api import cached_property
 from webrtc_models import RTCConfiguration, RTCIceCandidateInit, RTCIceServer
 from websockets.asyncio.client import connect as websocket_connect
 from wyzeapy import Wyzeapy, CameraService
-from wyzeapy.services.camera_service import Camera
+from wyzeapy.services.camera_service import Camera, DEVICEMGMT_API_MODELS
 
 from .const import CAMERA_UPDATED, CONF_CLIENT, DOMAIN
 from .token_manager import token_exception_handler
@@ -218,6 +218,17 @@ class WyzeCamera(CameraEntity):
             session_id,
         )
 
+        # Battery cameras must be told to wake and join the KVS signaling
+        # channel; without this the offer goes to a channel with no master
+        # and no answer ever arrives. Mirrors the my.wyze.com client, which
+        # runs the iot-device wakeup action before sending its offer.
+        if self._camera.product_model in DEVICEMGMT_API_MODELS:
+            try:
+                await self._camera_service.turn_on(self._camera)
+                _LOGGER.debug("Sent wakeup for camera %s", self.name)
+            except Exception as err:
+                _LOGGER.warning("Wakeup failed for camera %s: %s", self.name, err)
+
         # Always fetch a truly fresh config so the signaling URL and ICE servers
         # are never stale — KVS signed URLs are single-use and short-lived.
         config = await self._camera_service.get_stream_info(self._camera)
@@ -290,6 +301,15 @@ class WyzeCameraWebRTCSession:
         self.sdp_answer = None
         # Set once connect() succeeds; send_candidate waits on this instead of reconnecting
         self._connected = asyncio.Event()
+        # KVS does not buffer messages for a master that has not joined yet.
+        # Cameras (battery models especially) can take 10-20 s to wake and
+        # join the channel, so the first offer and any trickled candidates
+        # sent before that are silently dropped. We keep the serialized offer
+        # and candidates and re-send them until the camera answers.
+        self._offer_payload_str: str | None = None
+        self._candidate_payloads: list[str] = []
+        self._answered = False
+        self._reoffer_task: asyncio.Task | None = None
 
     async def connect(self):
         """Establish the WebSocket connection to the KVS signaling URL.
@@ -343,6 +363,43 @@ class WyzeCameraWebRTCSession:
             str_payload,
         )
         await self.websocket.send(str_payload)
+        self._offer_payload_str = str_payload
+        if self._reoffer_task is None:
+            self._reoffer_task = asyncio.create_task(self._reoffer_loop())
+
+    async def _reoffer_loop(self):
+        """Re-send the offer (and candidates) until the camera answers.
+
+        The camera joins the signaling channel only after its wakeup, which
+        takes 10-20 s on battery models; everything sent before that is lost.
+        """
+        for attempt in range(2, 12):
+            await asyncio.sleep(4)
+            if self._answered or self.websocket is None:
+                return
+            try:
+                _LOGGER.debug(
+                    "Re-sending SDP offer for camera %s session %s (attempt %d)",
+                    self.camera.name,
+                    self.session_id,
+                    attempt,
+                )
+                await self.websocket.send(self._offer_payload_str)
+                for cand in self._candidate_payloads:
+                    await self.websocket.send(cand)
+            except Exception as err:
+                _LOGGER.debug(
+                    "Re-offer stopped for camera %s session %s: %s",
+                    self.camera.name,
+                    self.session_id,
+                    err,
+                )
+                return
+        _LOGGER.warning(
+            "Camera %s never answered the WebRTC offer for session %s",
+            self.camera.name,
+            self.session_id,
+        )
 
     async def send_candidate(self, candidate: RTCIceCandidateInit):
         """Send an ICE candidate to the Kinesis Video Streams signaling channel."""
@@ -381,9 +438,12 @@ class WyzeCameraWebRTCSession:
             str_payload,
         )
         await self.websocket.send(str_payload)
+        self._candidate_payloads.append(str_payload)
 
     def close_connection(self):
         """Close the WebSocket connection to the Kinesis Video Streams signaling channel."""
+        if self._reoffer_task is not None:
+            self._reoffer_task.cancel()
         if self.close is not None:
             self.close()
 
@@ -482,6 +542,17 @@ class WyzeCameraWebRTCSession:
                         )
                         self.callback(WebRTCCandidate(candidate=rtccandidate))
                     case "SDP_ANSWER":
+                        # Re-sent offers can produce more than one answer once the
+                        # camera joins; forwarding a second answer would corrupt the
+                        # frontend's peer connection state, so only the first counts.
+                        if self._answered:
+                            _LOGGER.debug(
+                                "Ignoring duplicate SDP answer for camera %s session %s",
+                                self.camera.name,
+                                self.session_id,
+                            )
+                            continue
+                        self._answered = True
                         # Decode messagePayload (base64 JSON with "type"/"sdp" keys) → extract sdp string
                         answer_str = base64.b64decode(data["messagePayload"]).decode()
                         try:


### PR DESCRIPTION
Last of three related WebRTC fixes. Depends on #904 and #905, whose commits show in this diff for the same reason. Mine is the third, `fix: strip H.264 packetization mode 0 from the offer`.

Chrome offers H.264 twice per profile, packetization mode 1 and mode 0. The AN_RSCW cameras pick the mode 0 payload type and then send FU-A fragments anyway, which a mode 0 depacketiser has to discard. The connection reports itself healthy and decodes almost nothing: `getStats()` showed 1,757,262 bytes over 1,626 packets for exactly one decoded frame, against 189 frames on a camera that answered mode 1.

This removes every mode 0 H.264 payload type and its rtx companion from the offer before it reaches the camera. Rewriting the answer instead does nothing, which cost me an evening: Chrome keeps the fmtp it offered for its own payload type.

Tested on three AN_RSCW cameras at 1280x720, on LAN and remote, including first tap after a restart with an empty cache.
