### PR TITLE
Add a vacuum platform for the Wyze Robot Vacuum (JA_RO2)

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -44,6 +44,7 @@ PLATFORMS = [
     "number",
     "button",
     "camera",
+    "vacuum",
 ]  # Fixme: Re add scene
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -12,6 +12,7 @@ from wyzeapy.services.camera_service import Camera
 from wyzeapy.services.irrigation_service import Irrigation, IrrigationService
 from wyzeapy.services.lock_service import Lock
 from wyzeapy.services.switch_service import Switch, SwitchUsageService
+from wyzeapy.services.vacuum_service import Vacuum, VacuumService
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -25,6 +26,7 @@ from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
     UnitOfEnergy,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -74,6 +76,7 @@ async def async_setup_entry(
     switch_usage_service = await client.switch_usage_service
     irrigation_service = await client.irrigation_service
     air_purifier_service = await client.air_purifier_service
+    vacuum_service = await client.vacuum_service
 
     locks = await lock_service.get_locks()
     sensors = []
@@ -115,6 +118,15 @@ async def async_setup_entry(
                 WyzeIrrigationRSSI(irrigation_service, device),
                 WyzeIrrigationIP(irrigation_service, device),
                 WyzeIrrigationSSID(irrigation_service, device),
+            ]
+        )
+
+    for vacuum in await vacuum_service.get_vacuums():
+        sensors.extend(
+            [
+                WyzeVacuumLastCleanSizeSensor(vacuum_service, vacuum),
+                WyzeVacuumLastCleanDurationSensor(vacuum_service, vacuum),
+                WyzeVacuumLastCleanFinishedSensor(vacuum_service, vacuum),
             ]
         )
 
@@ -769,3 +781,111 @@ class WyzeAirPurifierHourlyMaxAQISensor(WyzeAirPurifierAirQualitySensor):
         if offset is not None:
             value += offset
         return value.isoformat()
+
+
+class WyzeVacuumLastCleanSensor(SensorEntity):
+    """Base class for sensors describing the vacuum's most recent cleaning run.
+
+    The vacuum's live `cleanSize` and `cleanTime` reset when it docks, so the
+    completed-run figures come from the cleaning history rather than device state.
+    """
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_should_poll = True
+
+    def __init__(self, vacuum_service: VacuumService, vacuum: Vacuum) -> None:
+        """Initialize the sensor."""
+        self._vacuum_service = vacuum_service
+        self._vacuum = vacuum
+        self._record: dict[str, Any] | None = None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._vacuum.mac)},
+            name=self._vacuum.nickname,
+            manufacturer="WyzeLabs",
+            model=self._vacuum.product_model,
+        )
+
+    async def async_update(self) -> None:
+        """Fetch the most recent cleaning record."""
+        self._record = await self._vacuum_service.get_last_clean(self._vacuum)
+
+
+class WyzeVacuumLastCleanSizeSensor(WyzeVacuumLastCleanSensor):
+    """How much the vacuum covered on its most recent cleaning run.
+
+    Wyze publishes `cleanSize` without stating a unit, and nothing in the API
+    identifies one, so the raw figure is reported and carries no unit or device
+    class. It is comparable between runs, which is what it is useful for.
+    """
+
+    _attr_translation_key = "last_clean_size"
+    _attr_name = "Last clean size"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, vacuum_service: VacuumService, vacuum: Vacuum) -> None:
+        """Initialize the sensor."""
+        super().__init__(vacuum_service, vacuum)
+        self._attr_unique_id = f"{vacuum.mac}-last-clean-size"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the run's clean size."""
+        return self._record.get("cleanSize") if self._record else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return how the run was started and what kind of run it was."""
+        if not self._record:
+            return {}
+        return {
+            "clean_type": self._record.get("cleanTypeText"),
+            "launch_type": self._record.get("launchTypeText"),
+        }
+
+
+class WyzeVacuumLastCleanDurationSensor(WyzeVacuumLastCleanSensor):
+    """How long the vacuum's most recent cleaning run took."""
+
+    _attr_translation_key = "last_clean_duration"
+    _attr_name = "Last clean duration"
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, vacuum_service: VacuumService, vacuum: Vacuum) -> None:
+        """Initialize the sensor."""
+        super().__init__(vacuum_service, vacuum)
+        self._attr_unique_id = f"{vacuum.mac}-last-clean-duration"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the run duration in minutes."""
+        return self._record.get("cleanTime") if self._record else None
+
+
+class WyzeVacuumLastCleanFinishedSensor(WyzeVacuumLastCleanSensor):
+    """When the vacuum's most recent cleaning run finished."""
+
+    _attr_translation_key = "last_clean_finished"
+    _attr_name = "Last clean finished"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def __init__(self, vacuum_service: VacuumService, vacuum: Vacuum) -> None:
+        """Initialize the sensor."""
+        super().__init__(vacuum_service, vacuum)
+        self._attr_unique_id = f"{vacuum.mac}-last-clean-finished"
+
+    @property
+    def native_value(self) -> datetime.datetime | None:
+        """Return the run's completion time."""
+        if not self._record:
+            return None
+        created = self._record.get("create_time")
+        if created is None:
+            return None
+        return datetime.datetime.fromtimestamp(created / 1000, tz=datetime.UTC)

--- a/custom_components/wyzeapi/vacuum.py
+++ b/custom_components/wyzeapi/vacuum.py
@@ -1,0 +1,218 @@
+"""Platform for robot vacuum integration."""
+
+from collections.abc import Callable
+import logging
+from typing import Any
+
+from aiohttp.client_exceptions import ClientConnectionError
+from wyzeapy import Wyzeapy
+from wyzeapy.exceptions import ParameterError, UnknownApiError
+from wyzeapy.services.vacuum_service import (
+    Vacuum,
+    VacuumMode,
+    VacuumService,
+    VacuumSuctionLevel,
+)
+
+from homeassistant.components.vacuum import (
+    StateVacuumEntity,
+    VacuumActivity,
+    VacuumEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import CONF_CLIENT, DOMAIN
+from .token_manager import token_exception_handler
+
+_LOGGER = logging.getLogger(__name__)
+ATTRIBUTION = "Data provided by Wyze"
+
+FAN_SPEEDS = [level.description for level in VacuumSuctionLevel]
+
+ACTIVITY_BY_MODE = {
+    VacuumMode.IDLE: VacuumActivity.IDLE,
+    VacuumMode.CLEANING: VacuumActivity.CLEANING,
+    VacuumMode.SWEEPING: VacuumActivity.CLEANING,
+    VacuumMode.MAPPING: VacuumActivity.CLEANING,
+    VacuumMode.PAUSED: VacuumActivity.PAUSED,
+    VacuumMode.MAPPING_PAUSED: VacuumActivity.PAUSED,
+    VacuumMode.BREAK_POINT: VacuumActivity.PAUSED,
+    VacuumMode.RETURNING_TO_CHARGE: VacuumActivity.RETURNING,
+    VacuumMode.FINISHED_RETURNING_TO_CHARGE: VacuumActivity.RETURNING,
+    VacuumMode.MAPPING_FINISHED_RETURNING_TO_CHARGE: VacuumActivity.RETURNING,
+    VacuumMode.DOCKED_NOT_COMPLETE: VacuumActivity.DOCKED,
+    VacuumMode.MAPPING_DOCKED_NOT_COMPLETE: VacuumActivity.DOCKED,
+}
+
+
+@token_exception_handler
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[list[Any], bool], None],
+) -> None:
+    """Set up Wyze robot vacuum entities."""
+
+    _LOGGER.debug("""Creating new WyzeApi vacuum component""")
+    client: Wyzeapy = hass.data[DOMAIN][config_entry.entry_id][CONF_CLIENT]
+    vacuum_service = await client.vacuum_service
+
+    vacuums = [
+        WyzeVacuum(vacuum_service, vacuum)
+        for vacuum in await vacuum_service.get_vacuums()
+    ]
+
+    async_add_entities(vacuums, True)
+
+
+class WyzeVacuum(StateVacuumEntity):
+    """Representation of a Wyze robot vacuum."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_should_poll = False
+    _attr_supported_features = (
+        VacuumEntityFeature.START
+        | VacuumEntityFeature.PAUSE
+        | VacuumEntityFeature.STOP
+        | VacuumEntityFeature.RETURN_HOME
+        | VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.BATTERY
+        | VacuumEntityFeature.STATE
+    )
+    _attr_fan_speed_list = FAN_SPEEDS
+    _just_updated = False
+
+    def __init__(self, vacuum_service: VacuumService, vacuum: Vacuum) -> None:
+        """Initialize the vacuum."""
+        self._vacuum_service = vacuum_service
+        self._vacuum = vacuum
+        self._attr_unique_id = f"{self._vacuum.mac}-vacuum"
+
+    @property
+    def device_info(self):
+        """Return device information about this entity."""
+        return {
+            "identifiers": {(DOMAIN, self._vacuum.mac)},
+            "name": self._vacuum.nickname,
+            "manufacturer": "WyzeLabs",
+            "model": self._vacuum.product_model,
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return the connection status of this vacuum."""
+        return self._vacuum.available
+
+    @property
+    def activity(self) -> VacuumActivity:
+        """Return what the vacuum is doing.
+
+        A recognised fault outranks the reported mode: a vacuum wedged under a
+        couch keeps reporting CLEANING, so trusting the mode alone hides the one
+        state the owner needs to act on. Only a recognised one, though. Wyze
+        publishes a fault code on every read, and a healthy docked vacuum reports
+        an undocumented non-zero code steadily; treating that as a fault would
+        pin the entity to ERROR forever.
+        """
+        if self._vacuum.fault is not None:
+            return VacuumActivity.ERROR
+        if self._vacuum.charging:
+            return VacuumActivity.DOCKED
+        return ACTIVITY_BY_MODE.get(self._vacuum.mode, VacuumActivity.IDLE)
+
+    @property
+    def battery_level(self) -> int | None:
+        """Return the battery level of the vacuum."""
+        return self._vacuum.battery
+
+    @property
+    def fan_speed(self) -> str | None:
+        """Return the current suction level."""
+        if self._vacuum.suction_level is None:
+            return None
+        return self._vacuum.suction_level.description
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the consumable life and last-clean detail."""
+        return {
+            "fault_code": self._vacuum.fault_code,
+            "fault": self._vacuum.fault.description if self._vacuum.fault else None,
+            "clean_size": self._vacuum.clean_size,
+            "clean_time": self._vacuum.clean_time,
+            "current_map_id": self._vacuum.current_map_id,
+            "filter_remaining": self._vacuum.filter_remaining,
+            "side_brush_remaining": self._vacuum.side_brush_remaining,
+            "main_brush_remaining": self._vacuum.main_brush_remaining,
+        }
+
+    @token_exception_handler
+    async def async_start(self) -> None:
+        """Start or resume a cleaning run."""
+        await self._command(self._vacuum_service.sweep)
+
+    @token_exception_handler
+    async def async_pause(self) -> None:
+        """Pause the cleaning run."""
+        await self._command(self._vacuum_service.pause)
+
+    @token_exception_handler
+    async def async_return_to_base(self, **kwargs: Any) -> None:
+        """Send the vacuum back to its dock."""
+        await self._command(self._vacuum_service.return_to_charge)
+
+    @token_exception_handler
+    async def async_stop(self, **kwargs: Any) -> None:
+        """Cancel a return-to-dock, leaving the vacuum where it stands."""
+        await self._command(self._vacuum_service.stop)
+
+    @token_exception_handler
+    async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
+        """Set the suction level."""
+        level = VacuumSuctionLevel.parse(fan_speed)
+        if level is None:
+            raise HomeAssistantError(f"Unsupported vacuum suction level: {fan_speed}")
+
+        await self._command(self._vacuum_service.set_suction_level, level)
+        self._vacuum.suction_level = level
+
+    async def _command(self, method: Callable, *args: Any) -> None:
+        """Issue a vacuum command, translating Wyze failures for the UI."""
+        try:
+            await method(self._vacuum, *args)
+        except (ParameterError, UnknownApiError) as err:
+            raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
+        except ClientConnectionError as err:
+            raise HomeAssistantError(err) from err
+        else:
+            self._just_updated = True
+            self.async_schedule_update_ha_state()
+
+    @token_exception_handler
+    async def async_update(self) -> None:
+        """Update the entity."""
+        if not self._just_updated:
+            self._vacuum = await self._vacuum_service.update(self._vacuum)
+        else:
+            self._just_updated = False
+
+    @callback
+    def async_update_callback(self, vacuum: Vacuum) -> None:
+        """Update the vacuum state."""
+        self._vacuum = vacuum
+        self.async_schedule_update_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to update events."""
+        self._vacuum.callback_function = self.async_update_callback
+        self._vacuum_service.register_updater(self._vacuum, 30)
+        await self._vacuum_service.start_update_manager()
+        return await super().async_added_to_hass()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister updater on removal."""
+        self._vacuum_service.unregister_updater(self._vacuum)

--- a/custom_components/wyzeapi/vacuum.py
+++ b/custom_components/wyzeapi/vacuum.py
@@ -31,6 +31,26 @@ ATTRIBUTION = "Data provided by Wyze"
 
 FAN_SPEEDS = [level.description for level in VacuumSuctionLevel]
 
+# Wyze refuses a command to a sleeping vacuum with this code. Availability stops
+# most such commands before they are sent; this catches the vacuum falling asleep
+# between a poll and a command, and turns the raw error dict into something the
+# owner can act on.
+OFFLINE_ERROR_CODE = 3000
+
+# `vacuum.send_command` command name for cleaning a subset of the map.
+CLEAN_ROOMS_COMMAND = "clean_rooms"
+
+
+def _is_offline_refusal(err: Exception) -> bool:
+    """Was this Wyze error the "Device is offline" refusal?"""
+    # Venus returns the code as an int, but Wyze is inconsistent about this across
+    # its services, so compare as a string rather than trusting the type.
+    for arg in err.args:
+        if isinstance(arg, dict) and str(arg.get("code")) == str(OFFLINE_ERROR_CODE):
+            return True
+    return False
+
+
 ACTIVITY_BY_MODE = {
     VacuumMode.IDLE: VacuumActivity.IDLE,
     VacuumMode.CLEANING: VacuumActivity.CLEANING,
@@ -82,6 +102,7 @@ class WyzeVacuum(StateVacuumEntity):
         | VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.BATTERY
         | VacuumEntityFeature.STATE
+        | VacuumEntityFeature.SEND_COMMAND
     )
     _attr_fan_speed_list = FAN_SPEEDS
     _just_updated = False
@@ -90,6 +111,7 @@ class WyzeVacuum(StateVacuumEntity):
         """Initialize the vacuum."""
         self._vacuum_service = vacuum_service
         self._vacuum = vacuum
+        self._rooms: dict[str, int] = {}
         self._attr_unique_id = f"{self._vacuum.mac}-vacuum"
 
     @property
@@ -104,19 +126,24 @@ class WyzeVacuum(StateVacuumEntity):
 
     @property
     def available(self) -> bool:
-        """Return the connection status of this vacuum."""
+        """Return the connection status of this vacuum.
+
+        The JA_RO2 sleeps on its dock and reports itself disconnected while the
+        cloud still answers reads in full. Availability follows commandability
+        rather than readability, because Wyze refuses every command to a sleeping
+        vacuum: a greyed-out button is the honest signal, where an enabled one
+        would fail at the API.
+        """
         return self._vacuum.available
 
     @property
     def activity(self) -> VacuumActivity:
         """Return what the vacuum is doing.
 
-        A recognised fault outranks the reported mode: a vacuum wedged under a
-        couch keeps reporting CLEANING, so trusting the mode alone hides the one
-        state the owner needs to act on. Only a recognised one, though. Wyze
-        publishes a fault code on every read, and a healthy docked vacuum reports
-        an undocumented non-zero code steadily; treating that as a fault would
-        pin the entity to ERROR forever.
+        A recognised fault outranks the reported mode, because a vacuum wedged
+        under a couch keeps reporting CLEANING and the fault is the state its
+        owner needs to act on. Recognition matters: `fault_code` also carries
+        routine status, so only a code the firmware documents as a fault counts.
         """
         if self._vacuum.fault is not None:
             return VacuumActivity.ERROR
@@ -140,6 +167,7 @@ class WyzeVacuum(StateVacuumEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the consumable life and last-clean detail."""
         return {
+            "rooms": sorted(self._rooms),
             "fault_code": self._vacuum.fault_code,
             "fault": self._vacuum.fault.description if self._vacuum.fault else None,
             "clean_size": self._vacuum.clean_size,
@@ -180,11 +208,68 @@ class WyzeVacuum(StateVacuumEntity):
         await self._command(self._vacuum_service.set_suction_level, level)
         self._vacuum.suction_level = level
 
+    @token_exception_handler
+    async def async_send_command(
+        self,
+        command: str,
+        params: dict[str, Any] | list[Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Run a vacuum command that has no standard Home Assistant service.
+
+        Supports `clean_rooms` with a `rooms` list of room names or ids, so an
+        automation can say "clean the Kitchen" without carrying the map's ids.
+        """
+        if command != CLEAN_ROOMS_COMMAND:
+            raise HomeAssistantError(f"Unsupported vacuum command: {command}")
+
+        params = params or {}
+        rooms = params.get("rooms") if isinstance(params, dict) else None
+        if isinstance(rooms, (str, int)):
+            rooms = [rooms]
+        if not rooms:
+            raise HomeAssistantError(
+                f"{CLEAN_ROOMS_COMMAND} needs a 'rooms' list. "
+                f"Known rooms: {', '.join(sorted(self._rooms)) or 'none discovered'}"
+            )
+
+        await self._command(self._vacuum_service.sweep_rooms, self._resolve(rooms))
+
+    def _resolve(self, rooms: list[Any]) -> list[int]:
+        """Turn room names or ids into the ids the map uses."""
+        by_lower = {name.lower(): room_id for name, room_id in self._rooms.items()}
+        ids = []
+        for room in rooms:
+            if isinstance(room, int):
+                ids.append(room)
+                continue
+            room_id = by_lower.get(str(room).strip().lower())
+            if room_id is None:
+                raise HomeAssistantError(
+                    f"Unknown room {room!r}. "
+                    f"Known rooms: {', '.join(sorted(self._rooms)) or 'none discovered'}"
+                )
+            ids.append(room_id)
+        return ids
+
+    async def _refresh_rooms(self) -> None:
+        """Cache the current map's rooms, tolerating a vacuum that cannot answer."""
+        try:
+            self._rooms = await self._vacuum_service.get_rooms(self._vacuum)
+        except (ParameterError, UnknownApiError, ClientConnectionError) as err:
+            # Room names are a convenience; every other command works without them.
+            _LOGGER.debug("Could not read rooms for %s: %s", self._vacuum.nickname, err)
+
     async def _command(self, method: Callable, *args: Any) -> None:
         """Issue a vacuum command, translating Wyze failures for the UI."""
         try:
             await method(self._vacuum, *args)
         except (ParameterError, UnknownApiError) as err:
+            if _is_offline_refusal(err):
+                raise HomeAssistantError(
+                    f"{self._vacuum.nickname} is asleep and Wyze refused the "
+                    "command. Try again once it reports as available."
+                ) from err
             raise HomeAssistantError(f"Wyze returned an error: {err.args}") from err
         except ClientConnectionError as err:
             raise HomeAssistantError(err) from err
@@ -208,6 +293,7 @@ class WyzeVacuum(StateVacuumEntity):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to update events."""
+        await self._refresh_rooms()
         self._vacuum.callback_function = self.async_update_callback
         self._vacuum_service.register_updater(self._vacuum, 30)
         await self._vacuum_service.start_update_manager()

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -58,6 +58,8 @@ def service() -> SimpleNamespace:
         return_to_charge=AsyncMock(),
         stop=AsyncMock(),
         set_suction_level=AsyncMock(),
+        sweep_rooms=AsyncMock(),
+        get_rooms=AsyncMock(return_value={}),
         update=AsyncMock(),
     )
 
@@ -183,6 +185,23 @@ def test_availability_follows_the_device(entity, vacuum):
     assert entity.available is False
 
 
+def test_a_sleeping_vacuum_stays_unavailable_though_its_state_still_reads(
+    entity, vacuum
+):
+    """Sleep is unavailability here, deliberately, and this pins that down.
+
+    A docked JA_RO2 reports `iot_state: disconnected` while the cloud keeps
+    answering reads, so battery and mode are still populated and it is tempting to
+    call the entity available. Wyze refuses every command in that state with code
+    3000, so availability has to follow the device, not the readability of state.
+    """
+    vacuum.available = False
+
+    assert entity.available is False
+    assert entity.battery_level == 100
+    assert entity.activity is VacuumActivity.DOCKED
+
+
 @pytest.mark.asyncio
 async def test_start_sweeps(entity, service, vacuum):
     await entity.async_start()
@@ -243,6 +262,37 @@ async def test_a_service_error_surfaces_as_a_home_assistant_error(
 
 
 @pytest.mark.asyncio
+async def test_an_offline_refusal_says_the_vacuum_is_asleep(entity, service):
+    """The poll/command race gets a sentence, not the raw Wyze error dict.
+
+    Availability normally stops a command to a sleeping vacuum before it is sent,
+    so this fires when it falls asleep between the two.
+    """
+    service.sweep.side_effect = UnknownApiError(
+        {"code": 3000, "message": "Device is offline", "data": None}
+    )
+
+    with pytest.raises(HomeAssistantError) as raised:
+        await entity.async_start()
+
+    assert "Diogee is asleep" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_a_non_offline_error_keeps_the_raw_detail(entity, service):
+    """Only code 3000 is translated; anything else must not lose its detail."""
+    service.sweep.side_effect = UnknownApiError(
+        {"code": 1004, "message": "Signature2 is invalid"}
+    )
+
+    with pytest.raises(HomeAssistantError) as raised:
+        await entity.async_start()
+
+    assert "Signature2 is invalid" in str(raised.value)
+    assert "asleep" not in str(raised.value)
+
+
+@pytest.mark.asyncio
 async def test_update_skips_the_poll_right_after_a_command(entity, service):
     await entity.async_start()
     service.update.reset_mock()
@@ -254,6 +304,79 @@ async def test_update_skips_the_poll_right_after_a_command(entity, service):
     await entity.async_update()
 
     service.update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_command_cleans_rooms_by_name(entity, service, vacuum):
+    entity._rooms = {"Kitchen": 16, "Laundry": 14}
+
+    await entity.async_send_command("clean_rooms", {"rooms": ["Kitchen", "Laundry"]})
+
+    service.sweep_rooms.assert_awaited_once_with(vacuum, [16, 14])
+
+
+@pytest.mark.asyncio
+async def test_send_command_accepts_room_ids(entity, service, vacuum):
+    entity._rooms = {"Kitchen": 16}
+
+    await entity.async_send_command("clean_rooms", {"rooms": [16]})
+
+    service.sweep_rooms.assert_awaited_once_with(vacuum, [16])
+
+
+@pytest.mark.asyncio
+async def test_send_command_accepts_a_bare_room_name(entity, service, vacuum):
+    entity._rooms = {"Kitchen": 16}
+
+    await entity.async_send_command("clean_rooms", {"rooms": "Kitchen"})
+
+    service.sweep_rooms.assert_awaited_once_with(vacuum, [16])
+
+
+@pytest.mark.asyncio
+async def test_send_command_matches_a_room_name_case_insensitively(
+    entity, service, vacuum
+):
+    entity._rooms = {"Master Bedroom": 12}
+
+    await entity.async_send_command("clean_rooms", {"rooms": ["master bedroom"]})
+
+    service.sweep_rooms.assert_awaited_once_with(vacuum, [12])
+
+
+@pytest.mark.asyncio
+async def test_send_command_names_the_known_rooms_when_one_is_wrong(entity, service):
+    entity._rooms = {"Kitchen": 16, "Laundry": 14}
+
+    with pytest.raises(HomeAssistantError) as err:
+        await entity.async_send_command("clean_rooms", {"rooms": ["Kitchn"]})
+
+    assert "Kitchen" in str(err.value)
+    service.sweep_rooms.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_command_rejects_an_empty_room_list(entity, service):
+    entity._rooms = {"Kitchen": 16}
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_send_command("clean_rooms", {"rooms": []})
+
+    service.sweep_rooms.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_command_rejects_an_unknown_command(entity, service):
+    with pytest.raises(HomeAssistantError):
+        await entity.async_send_command("mow_the_lawn", {})
+
+    service.sweep_rooms.assert_not_awaited()
+
+
+def test_rooms_are_exposed_as_an_attribute(entity):
+    entity._rooms = {"Kitchen": 16, "Laundry": 14}
+
+    assert entity.extra_state_attributes["rooms"] == ["Kitchen", "Laundry"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -1,0 +1,272 @@
+"""Tests for the Wyze robot vacuum entity."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from aiohttp.client_exceptions import ClientConnectionError
+from homeassistant.components.vacuum import VacuumActivity, VacuumEntityFeature
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+from wyzeapy.exceptions import ParameterError, UnknownApiError
+from wyzeapy.services.vacuum_service import (
+    VacuumFaultCode,
+    VacuumMode,
+    VacuumSuctionLevel,
+)
+
+from custom_components.wyzeapi import PLATFORMS
+from custom_components.wyzeapi import vacuum as vacuum_module
+from custom_components.wyzeapi.const import CONF_CLIENT, DOMAIN
+from custom_components.wyzeapi.vacuum import WyzeVacuum
+
+
+@pytest.fixture
+def vacuum() -> SimpleNamespace:
+    """Return a representative vacuum, docked and charged."""
+    return SimpleNamespace(
+        mac="JA_RO2_ABCDEF1234567890",
+        nickname="Diogee",
+        product_model="JA_RO2",
+        available=True,
+        mode=VacuumMode.IDLE,
+        battery=100,
+        charging=True,
+        clean_size=0,
+        clean_time=0,
+        suction_level=VacuumSuctionLevel.QUIET,
+        fault_code=2105,
+        fault=None,
+        current_map_id=None,
+        filter_remaining=461,
+        side_brush_remaining=445,
+        main_brush_remaining=461,
+        callback_function=None,
+    )
+
+
+@pytest.fixture
+def service() -> SimpleNamespace:
+    """Return a mocked vacuum service."""
+    return SimpleNamespace(
+        get_vacuums=AsyncMock(return_value=[]),
+        register_updater=Mock(),
+        unregister_updater=Mock(),
+        start_update_manager=AsyncMock(),
+        sweep=AsyncMock(),
+        pause=AsyncMock(),
+        return_to_charge=AsyncMock(),
+        stop=AsyncMock(),
+        set_suction_level=AsyncMock(),
+        update=AsyncMock(),
+    )
+
+
+@pytest.fixture
+def entity(service, vacuum) -> WyzeVacuum:
+    """Return a vacuum entity wired to the mocked service."""
+    entity = WyzeVacuum(service, vacuum)
+    entity.async_schedule_update_ha_state = Mock()
+    entity.hass = Mock()
+    return entity
+
+
+def test_vacuum_is_a_registered_platform():
+    assert "vacuum" in PLATFORMS
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_one_entity_per_vacuum(service, vacuum):
+    """The real vacuum platform setup creates one entity per discovered vacuum."""
+    service.get_vacuums.return_value = [vacuum]
+    service_future = asyncio.Future()
+    service_future.set_result(service)
+    client = SimpleNamespace(vacuum_service=service_future)
+    config_entry = SimpleNamespace(entry_id="entry-id")
+    hass = SimpleNamespace(
+        data={DOMAIN: {config_entry.entry_id: {CONF_CLIENT: client}}}
+    )
+    async_add_entities = Mock()
+
+    await vacuum_module.async_setup_entry(hass, config_entry, async_add_entities)
+
+    entities, update_before_add = async_add_entities.call_args.args
+    assert update_before_add is True
+    assert len(entities) == 1
+    assert isinstance(entities[0], WyzeVacuum)
+    assert entities[0].unique_id == f"{vacuum.mac}-vacuum"
+
+
+def test_supported_features_cover_the_venus_command_set(entity):
+    for feature in (
+        VacuumEntityFeature.START,
+        VacuumEntityFeature.PAUSE,
+        VacuumEntityFeature.STOP,
+        VacuumEntityFeature.RETURN_HOME,
+        VacuumEntityFeature.FAN_SPEED,
+        VacuumEntityFeature.BATTERY,
+        VacuumEntityFeature.STATE,
+    ):
+        assert entity.supported_features & feature
+
+
+def test_device_info_identifies_the_vacuum(entity, vacuum):
+    info = entity.device_info
+
+    assert info["identifiers"] == {(DOMAIN, vacuum.mac)}
+    assert info["name"] == "Diogee"
+    assert info["model"] == "JA_RO2"
+    assert info["manufacturer"] == "WyzeLabs"
+
+
+@pytest.mark.parametrize(
+    ("mode", "charging", "expected"),
+    [
+        (VacuumMode.IDLE, True, VacuumActivity.DOCKED),
+        (VacuumMode.IDLE, False, VacuumActivity.IDLE),
+        (VacuumMode.CLEANING, False, VacuumActivity.CLEANING),
+        (VacuumMode.SWEEPING, False, VacuumActivity.CLEANING),
+        (VacuumMode.MAPPING, False, VacuumActivity.CLEANING),
+        (VacuumMode.PAUSED, False, VacuumActivity.PAUSED),
+        (VacuumMode.MAPPING_PAUSED, False, VacuumActivity.PAUSED),
+        (VacuumMode.RETURNING_TO_CHARGE, False, VacuumActivity.RETURNING),
+        (VacuumMode.FINISHED_RETURNING_TO_CHARGE, False, VacuumActivity.RETURNING),
+        (VacuumMode.DOCKED_NOT_COMPLETE, True, VacuumActivity.DOCKED),
+        (VacuumMode.UNKNOWN, False, VacuumActivity.IDLE),
+    ],
+)
+def test_activity_maps_every_mode(entity, vacuum, mode, charging, expected):
+    vacuum.mode = mode
+    vacuum.charging = charging
+
+    assert entity.activity is expected
+
+
+def test_a_fault_wins_over_the_reported_mode(entity, vacuum):
+    """A vacuum stuck mid-clean still reports CLEANING; the fault is the real state."""
+    vacuum.mode = VacuumMode.CLEANING
+    vacuum.fault_code = 510
+    vacuum.fault = VacuumFaultCode.COLLISION_EXCEPTION
+
+    assert entity.activity is VacuumActivity.ERROR
+
+
+def test_an_undocumented_fault_code_is_not_an_error(entity, vacuum):
+    """The real device reports 2105 while healthy and docked, on every read."""
+    vacuum.mode = VacuumMode.CLEANING
+    vacuum.charging = False
+    vacuum.fault_code = 2105
+    vacuum.fault = None
+
+    assert entity.activity is VacuumActivity.CLEANING
+
+
+def test_battery_and_fan_speed_are_reported(entity):
+    assert entity.battery_level == 100
+    assert entity.fan_speed == "Quiet"
+    assert entity.fan_speed_list == ["Quiet", "Standard", "Strong"]
+
+
+def test_extra_attributes_expose_consumable_life(entity):
+    attributes = entity.extra_state_attributes
+
+    assert attributes["filter_remaining"] == 461
+    assert attributes["side_brush_remaining"] == 445
+    assert attributes["main_brush_remaining"] == 461
+    assert attributes["fault_code"] == 2105
+    assert attributes["fault"] is None
+
+
+def test_availability_follows_the_device(entity, vacuum):
+    assert entity.available is True
+    vacuum.available = False
+    assert entity.available is False
+
+
+@pytest.mark.asyncio
+async def test_start_sweeps(entity, service, vacuum):
+    await entity.async_start()
+
+    service.sweep.assert_awaited_once_with(vacuum)
+
+
+@pytest.mark.asyncio
+async def test_pause_pauses(entity, service, vacuum):
+    await entity.async_pause()
+
+    service.pause.assert_awaited_once_with(vacuum)
+
+
+@pytest.mark.asyncio
+async def test_return_to_base_docks(entity, service, vacuum):
+    await entity.async_return_to_base()
+
+    service.return_to_charge.assert_awaited_once_with(vacuum)
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_the_return(entity, service, vacuum):
+    await entity.async_stop()
+
+    service.stop.assert_awaited_once_with(vacuum)
+
+
+@pytest.mark.asyncio
+async def test_set_fan_speed_sets_the_suction_level(entity, service, vacuum):
+    await entity.async_set_fan_speed("Strong")
+
+    service.set_suction_level.assert_awaited_once_with(
+        vacuum, VacuumSuctionLevel.STRONG
+    )
+    assert vacuum.suction_level is VacuumSuctionLevel.STRONG
+
+
+@pytest.mark.asyncio
+async def test_set_fan_speed_rejects_an_unknown_speed(entity, service):
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_fan_speed("Turbo")
+
+    service.set_suction_level.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "error", [ParameterError("boom"), UnknownApiError("boom"), ClientConnectionError()]
+)
+@pytest.mark.asyncio
+async def test_a_service_error_surfaces_as_a_home_assistant_error(
+    entity, service, error
+):
+    service.sweep.side_effect = error
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_start()
+
+
+@pytest.mark.asyncio
+async def test_update_skips_the_poll_right_after_a_command(entity, service):
+    await entity.async_start()
+    service.update.reset_mock()
+
+    await entity.async_update()
+
+    service.update.assert_not_awaited()
+
+    await entity.async_update()
+
+    service.update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_added_to_hass_registers_the_updater(entity, service, vacuum):
+    await entity.async_added_to_hass()
+
+    service.register_updater.assert_called_once_with(vacuum, 30)
+    service.start_update_manager.assert_awaited_once()
+    assert vacuum.callback_function == entity.async_update_callback
+
+
+@pytest.mark.asyncio
+async def test_removal_unregisters_the_updater(entity, service, vacuum):
+    await entity.async_will_remove_from_hass()
+
+    service.unregister_updater.assert_called_once_with(vacuum)

--- a/tests/test_vacuum_sensors.py
+++ b/tests/test_vacuum_sensors.py
@@ -1,0 +1,93 @@
+"""Tests for the Wyze vacuum's last-clean sensors."""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.wyzeapi.sensor import (
+    WyzeVacuumLastCleanDurationSensor,
+    WyzeVacuumLastCleanFinishedSensor,
+    WyzeVacuumLastCleanSizeSensor,
+)
+from custom_components.wyzeapi.const import DOMAIN
+
+RECORD = {
+    "cleanSize": 694,
+    "cleanTime": 15,
+    "cleanTypeText": "House Vacuuming",
+    "launchTypeText": "Manual",
+    "create_time": 1785764496542,
+}
+
+
+@pytest.fixture
+def vacuum() -> SimpleNamespace:
+    """Return a representative vacuum."""
+    return SimpleNamespace(
+        mac="JA_RO2_ABCDEF1234567890",
+        nickname="Diogee",
+        product_model="JA_RO2",
+    )
+
+
+@pytest.fixture
+def service() -> SimpleNamespace:
+    """Return a mocked vacuum service holding one cleaning record."""
+    return SimpleNamespace(get_last_clean=AsyncMock(return_value=RECORD))
+
+
+@pytest.mark.asyncio
+async def test_size_sensor_reports_the_raw_figure(service, vacuum):
+    sensor = WyzeVacuumLastCleanSizeSensor(service, vacuum)
+    await sensor.async_update()
+
+    assert sensor.native_value == 694
+    assert sensor.native_unit_of_measurement is None
+    assert sensor.unique_id == f"{vacuum.mac}-last-clean-size"
+    assert sensor.extra_state_attributes["launch_type"] == "Manual"
+
+
+@pytest.mark.asyncio
+async def test_duration_sensor_reports_minutes(service, vacuum):
+    sensor = WyzeVacuumLastCleanDurationSensor(service, vacuum)
+    await sensor.async_update()
+
+    assert sensor.native_value == 15
+    assert sensor.native_unit_of_measurement == "min"
+
+
+@pytest.mark.asyncio
+async def test_finished_sensor_reports_an_aware_timestamp(service, vacuum):
+    sensor = WyzeVacuumLastCleanFinishedSensor(service, vacuum)
+    await sensor.async_update()
+
+    value = sensor.native_value
+    assert isinstance(value, datetime.datetime)
+    assert value.tzinfo is not None
+    assert value == datetime.datetime.fromtimestamp(
+        RECORD["create_time"] / 1000, tz=datetime.UTC
+    )
+
+
+@pytest.mark.asyncio
+async def test_sensors_report_none_without_history(vacuum):
+    """A vacuum that has never run has no record, and must not raise."""
+    service = SimpleNamespace(get_last_clean=AsyncMock(return_value=None))
+    for cls in (
+        WyzeVacuumLastCleanSizeSensor,
+        WyzeVacuumLastCleanDurationSensor,
+        WyzeVacuumLastCleanFinishedSensor,
+    ):
+        sensor = cls(service, vacuum)
+        await sensor.async_update()
+        assert sensor.native_value is None
+
+
+@pytest.mark.asyncio
+async def test_sensors_attach_to_the_vacuum_device(service, vacuum):
+    sensor = WyzeVacuumLastCleanSizeSensor(service, vacuum)
+
+    assert sensor.device_info["identifiers"] == {(DOMAIN, vacuum.mac)}
+    assert sensor.device_info["name"] == "Diogee"


### PR DESCRIPTION
Closes #281.

## What

Adds the missing `vacuum` platform, so a Wyze Robot Vacuum finally appears in Home Assistant.

Today the JA_RO2 is returned by the account device list and then dropped: there is no platform for it here and no vacuum service in `wyzeapy`, so the device is simply invisible. On my account the integration registers 19 of 28 account devices and the vacuum is one of the nine that never arrive.

## Depends on

**SecKatie/wyzeapy#325**, which adds the `VacuumService` this consumes. The manifest pin needs bumping to whichever `wyzeapy` release carries it before this merges; happy to push that commit once the version is known.

## Surface

- **Vacuum entity**: `start`, `pause`, `stop`, `return_to_base`, suction level as `fan_speed` (Quiet / Standard / Strong), `battery_level`, and consumable life for the filter and both brushes as attributes.
- **Room cleaning**: `vacuum.send_command` with `clean_rooms` and a `rooms` list of names or ids, so an automation reads "clean the Kitchen" rather than carrying the map's ids. The room list is cached at setup and exposed as a `rooms` attribute; an unrecognised name fails with the known rooms named.
- **Sensors**: size, duration and finish time of the most recent completed run. `cleanSize` carries no unit anywhere in the API, so it is reported raw with no unit or device class rather than guessing one.

## Three deliberate rules

- A vacuum on its dock reads `DOCKED` whatever the reported mode says.
- A **recognised** fault outranks the mode, because a vacuum wedged under a couch keeps reporting `CLEANING`. Only a documented fault counts: the device publishes an undocumented non-zero `fault_code` continuously while healthy, so gating on truthiness pins the entity to `error` on the dock. `fault_code` is still exposed as an attribute.
- `available` follows commandability rather than readability. A sleeping vacuum answers reads in full but Wyze refuses every command with code 3000, so a greyed-out button is the honest signal. That refusal is also caught and surfaced as a sentence naming the vacuum rather than a raw error dict, for the case where it falls asleep between a poll and a command.

## Verification

43 new tests; the full suite is 65 passing and ruff is clean.

Deployed to a live HA 2026.7.4 against a real JA_RO2:

- the entity registers, reads `docked` at 100% with suction `Quiet` and consumable life populated
- the suction level round trips from the UI with the change confirmed on read-back
- a real `vacuum.start` → `vacuum.return_to_base` cycle ran the robot and returned it to its dock
- the `rooms` attribute lists the seven mapped rooms, and a room-targeted script drove the vacuum into `cleaning` and back to `docked`
- the sensors populate from the cleaning history
- the tile and its command buttons were loaded in a browser and confirmed rendering