### PR TITLE
Fix camera light entities: reflect commanded state and follow camera availability

### DIFF
--- a/custom_components/wyzeapi/light.py
+++ b/custom_components/wyzeapi/light.py
@@ -390,7 +390,6 @@ class WyzeCamerafloodlight(LightEntity):
         self._service = camera_service
         self._light_type = light_type
         self._attr_unique_id = f"{self._device.mac}-{self._light_type}"
-        self._is_on = self._device.floodlight
 
     @token_exception_handler
     async def async_turn_on(self, **kwargs) -> None:
@@ -402,7 +401,9 @@ class WyzeCamerafloodlight(LightEntity):
         except ClientConnectionError as err:
             raise HomeAssistantError(err) from err
         else:
-            self._is_on = True
+            # Optimistic: is_on reads the camera object, which the next poll
+            # would otherwise only refresh up to INTERVAL seconds from now.
+            self._device.floodlight = True
             self._just_updated = True
             self.async_schedule_update_ha_state()
 
@@ -416,9 +417,14 @@ class WyzeCamerafloodlight(LightEntity):
         except ClientConnectionError as err:
             raise HomeAssistantError(err) from err
         else:
-            self._is_on = False
+            self._device.floodlight = False
             self._just_updated = True
             self.async_schedule_update_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """An offline camera cannot switch its light."""
+        return self._device.available
 
     @property
     def is_on(self):


### PR DESCRIPTION
## Problem
`WyzeCamerafloodlight` (floodlight, spotlight, bulb-cam light, lamp socket) never shows the state you just commanded:

- `async_turn_on()` / `async_turn_off()` set `self._is_on`, but the `is_on` property returns `self._device.floodlight`. Nothing writes to that until the camera's next poll arrives through `handle_camera_update()`.
- So `light.turn_on` returns with no state change, the UI toggle snaps back, and the light looks dead until the next poll. On accounts with many devices the update manager gives each device one slot per `INTERVAL` (300 s), so that is up to five minutes.
- The class has no `available` property, so the light of an offline camera still looks controllable and silently swallows commands.

This is the mechanism behind #671 ("toggle moves, then moves back", Floodlight V2) and #851 ("won't respond to toggle", Bulb Cam), both closed as stale.

## Measurements
ha-wyzeapi 0.1.39, wyzeapy 0.6.1, Home Assistant 2026.9.0, an account with ~120 Wyze devices (so ~300 s between polls of one device).

| entity | model | `light.turn_on` response | device acted | HA showed `on` after |
|---|---|---|---|---|
| Battery Cam Pro spotlight | AN_RSCW | HTTP 200, no state change | yes | 101 s (next poll) |
| Floodlight Pro floodlight | LD_CFP | HTTP 200, no state change | yes | 144 s (next poll) |
| the same two, `light.turn_off` | | HTTP 200, no state change | yes | 55 s / 98 s |
| Bulb Cam light | HL_BC | HTTP 200, no error | already on | — |

The Wyze API accepts every command and the devices act; only the entity lies until the next poll.

With this change `light.turn_on` returns `light.<entity>=on` immediately, the state held through the following polls, and the lights of three offline cameras became `unavailable`.

## Change
Mirrors what the switch platform already does for camera power (`self._device.on = True` in `switch.py`) and what `camera.py` does for availability:

- on success, write the optimistic value to `self._device.floodlight` (the next poll confirms or corrects it);
- add `available` returning `self._device.available` — `Device.__init__` starts it at `False` and the camera poll fills it from `iot-state` / `PropertyIDs.AVAILABLE`, exactly as `WyzeCamera.available` already behaves, so the light and its camera go unavailable and available together;
- drop the dead `_is_on` field.

## Testing
- Floodlight Pro (LD_CFP), Battery Cam Pro spotlight (AN_RSCW) and Bulb Cam (HL_BC) on HA 2026.9.0: toggles update immediately and agree with the next poll.
- Cameras that are offline (their `switch.<camera>_power` is unavailable) now show their light as unavailable.
- Restart plus ~30 min of normal polling with no new log entries from the light platform.

Not tested: lamp socket (`HL_CAM3SS` dongle) and Floodlight V2 (`HL_CFL2`); they share the class, so the change applies to them, but I do not have working units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)