### PR TITLE
Add IoT3 support for DX-family locks (Lock Bolt v2, Palm Lock)

### DIFF
--- a/custom_components/wyzeapi/__init__.py
+++ b/custom_components/wyzeapi/__init__.py
@@ -29,6 +29,8 @@ from .const import (
     API_KEY,
 )
 from .coordinator import WyzeLockBoltCoordinator
+from .iot3_coordinator import WyzeIot3LockCoordinator
+from .iot3_service import Iot3Service
 from .token_manager import TokenManager
 
 PLATFORMS = [
@@ -199,6 +201,42 @@ async def setup_coordinators(
     hass: HomeAssistant, config_entry: ConfigEntry, client: Wyzeapy
 ):
     """Set up coordinators for Wyze devices that require Bluetooth."""
+    # IoT3 (DX-family) locks first - no Bluetooth involved. These report
+    # product_type "Common", so lock_service.get_locks() never sees them; find
+    # them by product_model in the full device list instead.
+    from .const import IOT3_MODELS
+
+    try:
+        _lock_service = await client.lock_service
+        _all_devices = await _lock_service.get_object_list()
+        _iot3_devices = [d for d in _all_devices if d.product_model in IOT3_MODELS]
+    except Exception as exc:  # noqa: BLE001 - never block setup of everything else
+        _LOGGER.warning("Wyze IoT3 device discovery failed: %s", exc)
+        _iot3_devices = []
+    hass.data[DOMAIN][config_entry.entry_id]["iot3_devices"] = _iot3_devices
+    if _iot3_devices:
+        _iot3_service = Iot3Service(hass, config_entry, client)
+        hass.data[DOMAIN][config_entry.entry_id]["iot3_service"] = _iot3_service
+        _coordinators = hass.data[DOMAIN][config_entry.entry_id].setdefault(
+            "coordinators", {}
+        )
+        for _dev in _iot3_devices:
+            _LOGGER.info(
+                "Wyze IoT3: setting up %s (%s)", _dev.nickname, _dev.product_model
+            )
+            _coord = WyzeIot3LockCoordinator(hass, _iot3_service, _dev)
+            # Populate before platforms are forwarded so the entities do not
+            # sit unavailable for the first poll interval. async_refresh rather
+            # than async_config_entry_first_refresh on purpose: a sick lock API
+            # should not take the whole config entry down with it.
+            await _coord.async_refresh()
+            if not _coord.last_update_success:
+                _LOGGER.warning(
+                    "Wyze IoT3: first poll of %s failed; it will retry on its interval",
+                    _dev.nickname,
+                )
+            _coordinators[_dev.mac] = _coord
+
     # Check if Bluetooth is active and functioning
     if bluetooth.async_scanner_count(hass, connectable=True) == 0:
         _LOGGER.info(

--- a/custom_components/wyzeapi/const.py
+++ b/custom_components/wyzeapi/const.py
@@ -27,3 +27,15 @@ DEFAULT_LOCAL_CONTROL = True
 YDBLE_LOCK_STATE_UUID = "00002220-0000-6b63-6f6c-2e6b636f6f6c"
 YDBLE_UART_RX_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
 YDBLE_UART_TX_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+
+# Wyze IoT3 API, used by the DX device family.
+# Lock Bolt v2 (DX_LB2) and Palm Lock (DX_PVLOC) report product_type "Common" and
+# are served by a different cloud API than the Yunding locks.
+IOT3_APP_HOST = "https://app.wyzecam.com"
+IOT3_GET_PROPERTY_PATH = "/app/v4/iot3/get-property"
+IOT3_RUN_ACTION_PATH = "/app/v4/iot3/run-action"
+IOT3_APP_VERSION = "3.11.0.758"
+OLIVE_SIGNING_SECRET = "wyze_app_secret_key_132"
+OLIVE_APP_ID = "9319141212m2ik"
+OLIVE_APP_INFO = "wyze_android_3.11.0.758"
+IOT3_MODELS = {"DX_LB2", "DX_PVLOC"}

--- a/custom_components/wyzeapi/iot3_coordinator.py
+++ b/custom_components/wyzeapi/iot3_coordinator.py
@@ -1,0 +1,118 @@
+"""DataUpdateCoordinator for Wyze DX-family locks over the IoT3 API.
+
+Originally written by @zrikzlok for PR #809. A lock or unlock the API rejects
+raises HomeAssistantError, so a service call fails visibly instead of returning
+success while the door never moved.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .iot3_service import Iot3Service
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_INTERVAL = timedelta(seconds=30)
+
+
+class WyzeIot3LockCoordinator(DataUpdateCoordinator):
+    """Polls one DX-family lock (DX_LB2, DX_PVLOC) through the IoT3 cloud API."""
+
+    def __init__(self, hass: HomeAssistant, iot3_service: Iot3Service, lock):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"Wyze {lock.product_model} {lock.nickname}",
+            update_interval=UPDATE_INTERVAL,
+        )
+        self._iot3_service = iot3_service
+        self._lock = lock
+        self._current_command: str | None = None
+
+    @property
+    def device(self):
+        """The wyzeapy Device this coordinator drives."""
+        return self._lock
+
+    async def _async_update_data(self) -> dict:
+        if self._current_command is not None:
+            # a command is in flight; keep the optimistic state until it settles
+            return self.data or {}
+
+        try:
+            result = await self._iot3_service.get_properties(
+                self._lock.mac, self._lock.product_model
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise UpdateFailed(f"IoT3 poll failed: {exc}") from exc
+
+        if str(result.get("code")) != "1":
+            raise UpdateFailed(
+                f"IoT3 returned code={result.get('code')} msg={result.get('msg', 'unknown')}"
+            )
+
+        props = result.get("data", {}).get("props", {}) or {}
+        return {
+            "locked": props.get("lock::lock-status"),
+            "door_open": (
+                None
+                if props.get("lock::door-status") is None
+                else not props.get("lock::door-status")
+            ),
+            "online": props.get("iot-device::iot-state", False),
+            "battery_level": props.get("battery::battery-level"),
+            "power_source": props.get("battery::power-source"),
+            "firmware_ver": props.get("device-info::firmware-ver"),
+        }
+
+    async def lock_unlock(self, command: str) -> None:
+        """Lock or unlock.
+
+        A request the API rejects raises, so a service call fails visibly
+        instead of reporting success while the bolt never moved.
+
+        On success the commanded state is written straight into the coordinator's
+        data so the entity flips at once. Without that the entity keeps its old
+        state until the next scheduled poll - about 30 s on my locks - with no
+        in-progress hint in between. The poll that follows confirms it, or
+        corrects it if the bolt did not actually move (a jam or a tight strike
+        plate), so the optimistic value is never the last word.
+        """
+        if command not in ("lock", "unlock"):
+            raise HomeAssistantError(f"Unknown lock command {command!r}")
+
+        self._current_command = command
+        self.async_update_listeners()
+        try:
+            call = self._iot3_service.lock if command == "lock" else self._iot3_service.unlock
+            result = await call(self._lock.mac, self._lock.product_model)
+        except HomeAssistantError:
+            self._current_command = None
+            await self.async_request_refresh()
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self._current_command = None
+            await self.async_request_refresh()
+            raise HomeAssistantError(
+                f"Wyze {command} request failed for {self._lock.nickname}: {exc}"
+            ) from exc
+
+        self._current_command = None
+
+        if str(result.get("code")) != "1":
+            await self.async_request_refresh()
+            raise HomeAssistantError(
+                f"Wyze rejected the {command} request for {self._lock.nickname}: "
+                f"code={result.get('code')} msg={result.get('msg', 'unknown')}"
+            )
+
+        # accepted: reflect it now; the next scheduled poll reconciles with the device
+        data = dict(self.data or {})
+        data["locked"] = command == "lock"
+        self.async_set_updated_data(data)

--- a/custom_components/wyzeapi/iot3_service.py
+++ b/custom_components/wyzeapi/iot3_service.py
@@ -1,0 +1,159 @@
+"""IoT3 API service for Wyze DX-family devices (Lock Bolt v2, Palm Lock).
+
+Originally written by @zrikzlok for PR #809. The access token is taken from
+wyzeapy's auth layer and refreshed before every request, so it keeps working
+once the cached token ages out.
+
+DX-family devices report product_type "Common", so wyzeapy's get_locks() never
+returns them. They are found by product_model in the full device list and driven
+through Wyze's IoT3 cloud API rather than the Yunding lock endpoints.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import random
+import time
+import uuid
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import (
+    IOT3_APP_HOST,
+    IOT3_APP_VERSION,
+    IOT3_GET_PROPERTY_PATH,
+    IOT3_RUN_ACTION_PATH,
+    OLIVE_APP_ID,
+    OLIVE_APP_INFO,
+    OLIVE_SIGNING_SECRET,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PROPS = [
+    "lock::lock-status",
+    "lock::door-status",
+    "iot-device::iot-state",
+    "battery::battery-level",
+    "battery::power-source",
+    "device-info::firmware-ver",
+]
+
+
+class Iot3Service:
+    """Client for the Wyze IoT3 API used by DX-family devices."""
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry, client):
+        self._hass = hass
+        self._config_entry = config_entry
+        self._client = client  # wyzeapy.Wyzeapy - owns auth and token refresh
+        self._phone_id = str(uuid.uuid4())
+        self._session = async_get_clientsession(hass)
+
+    @property
+    def username(self) -> str:
+        return self._config_entry.data.get(CONF_USERNAME, "")
+
+    async def _get_access_token(self) -> str:
+        """Always go through wyzeapy's auth layer so an aged-out token is
+        refreshed rather than used and rejected."""
+        auth_lib = getattr(self._client, "_auth_lib", None)
+        if auth_lib is None or getattr(auth_lib, "token", None) is None:
+            raise HomeAssistantError(
+                "Wyze IoT3: no authenticated client available; reload the integration"
+            )
+        await auth_lib.refresh_if_should()
+        return auth_lib.token.access_token
+
+    @staticmethod
+    def _compute_signature(access_token: str, body: str) -> str:
+        access_key = access_token + OLIVE_SIGNING_SECRET
+        secret = hashlib.md5(access_key.encode()).hexdigest()
+        return hmac.new(secret.encode(), body.encode(), hashlib.md5).hexdigest()
+
+    def _build_headers(self, access_token: str, body: str) -> dict:
+        return {
+            "access_token": access_token,
+            "appid": OLIVE_APP_ID,
+            "appinfo": OLIVE_APP_INFO,
+            "appversion": IOT3_APP_VERSION,
+            "env": "Prod",
+            "phoneid": self._phone_id,
+            "requestid": uuid.uuid4().hex,
+            "Signature2": self._compute_signature(access_token, body),
+            "Content-Type": "application/json; charset=utf-8",
+        }
+
+    async def _post(self, path: str, payload: dict) -> dict:
+        access_token = await self._get_access_token()
+        body = json.dumps(payload)
+        headers = self._build_headers(access_token, body)
+        url = f"{IOT3_APP_HOST}{path}"
+        try:
+            async with self._session.post(url, headers=headers, data=body) as resp:
+                result = await resp.json()
+        except Exception as exc:  # noqa: BLE001 - surfaced by the caller
+            _LOGGER.error("IoT3 request to %s failed: %s", path, exc)
+            raise
+        if str(result.get("code")) != "1":
+            _LOGGER.debug(
+                "IoT3 %s returned code=%s msg=%s",
+                path,
+                result.get("code"),
+                result.get("msg"),
+            )
+        return result
+
+    async def get_properties(
+        self, device_mac: str, model: str, props: list[str] | None = None
+    ) -> dict:
+        """Read device properties. `model` comes from the device's product_model
+        rather than being parsed out of the MAC, so a device whose MAC is not
+        prefixed with its model still works."""
+        ts = int(time.time() * 1000)
+        payload = {
+            "nonce": str(ts),
+            "payload": {
+                "cmd": "get_property",
+                "props": list(props or DEFAULT_PROPS),
+                "tid": random.randint(1000, 99999),
+                "ts": ts,
+                "ver": 1,
+            },
+            "targetInfo": {"id": device_mac, "model": model},
+        }
+        return await self._post(IOT3_GET_PROPERTY_PATH, payload)
+
+    async def run_action(self, device_mac: str, model: str, action: str) -> dict:
+        """Run an action such as `lock::lock` or `lock::unlock`."""
+        ts = int(time.time() * 1000)
+        payload = {
+            "nonce": str(ts),
+            "payload": {
+                "action": action,
+                "cmd": "run_action",
+                "params": {
+                    "action_id": random.randint(10000, 99999),
+                    "type": 1,
+                    "username": self.username,
+                },
+                "tid": random.randint(1000, 99999),
+                "ts": ts,
+                "ver": 1,
+            },
+            "targetInfo": {"id": device_mac, "model": model},
+        }
+        return await self._post(IOT3_RUN_ACTION_PATH, payload)
+
+    async def lock(self, device_mac: str, model: str) -> dict:
+        return await self.run_action(device_mac, model, "lock::lock")
+
+    async def unlock(self, device_mac: str, model: str) -> dict:
+        return await self.run_action(device_mac, model, "lock::unlock")

--- a/custom_components/wyzeapi/lock.py
+++ b/custom_components/wyzeapi/lock.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers import device_registry as dr
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import CONF_CLIENT, DOMAIN, LOCK_UPDATED
+from .const import CONF_CLIENT, DOMAIN, IOT3_MODELS, LOCK_UPDATED
 from .token_manager import token_exception_handler
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,7 +71,16 @@ async def async_setup_entry(
                 continue
             lock_bolts.append(WyzeLockBolt(coordinator))
 
-    async_add_entities(locks + lock_bolts, False)
+    # DX-family locks come from the device list, not get_locks()
+    iot3_locks = []
+    for _dev in hass.data[DOMAIN][config_entry.entry_id].get("iot3_devices", []):
+        _coord = hass.data[DOMAIN][config_entry.entry_id].get("coordinators", {}).get(
+            _dev.mac
+        )
+        if _coord is not None:
+            iot3_locks.append(WyzeIot3Lock(_coord))
+
+    async_add_entities(locks + lock_bolts + iot3_locks, False)
 
 
 class WyzeLock(homeassistant.components.lock.LockEntity, ABC):
@@ -272,3 +281,69 @@ class WyzeLockBolt(CoordinatorEntity, homeassistant.components.lock.LockEntity):
         if self.coordinator.data is None:
             return {}
         return {"last_operated": self.coordinator.data["timestamp"]}
+
+
+# Wyze Lock Bolt v2 (DX_LB2) and Palm Lock (DX_PVLOC) over the IoT3 cloud API.
+class WyzeIot3Lock(CoordinatorEntity, homeassistant.components.lock.LockEntity):
+    """A Wyze DX-family lock driven through the IoT3 API."""
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._device = coordinator.device
+
+    @property
+    def name(self):
+        return self._device.nickname
+
+    @property
+    def unique_id(self):
+        return self._device.mac
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device.mac)},
+            "name": self._device.nickname,
+            "manufacturer": "WyzeLabs",
+            "model": self._device.product_model,
+        }
+
+    @property
+    def available(self):
+        if self.coordinator.data is None:
+            return False
+        return bool(self.coordinator.data.get("online", False))
+
+    @property
+    def is_locked(self):
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("locked")
+
+    @property
+    def is_locking(self):
+        return self.coordinator._current_command == "lock"
+
+    @property
+    def is_unlocking(self):
+        return self.coordinator._current_command == "unlock"
+
+    @property
+    def extra_state_attributes(self):
+        attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
+        data = self.coordinator.data or {}
+        for key, attr in (
+            ("battery_level", "battery_level"),
+            ("firmware_ver", "firmware_version"),
+            ("door_open", "door_open"),
+            ("power_source", "power_source"),
+        ):
+            if data.get(key) is not None:
+                attrs[attr] = data[key]
+        return attrs
+
+    async def async_lock(self, **kwargs):
+        await self.coordinator.lock_unlock("lock")
+
+    async def async_unlock(self, **kwargs):
+        await self.coordinator.lock_unlock("unlock")

--- a/custom_components/wyzeapi/sensor.py
+++ b/custom_components/wyzeapi/sensor.py
@@ -36,8 +36,11 @@ from homeassistant.helpers.event import (
     async_track_time_change,
 )
 
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
 from .const import (
     AIR_PURIFIER_UPDATED,
+    IOT3_MODELS,
     CAMERA_UPDATED,
     CONF_CLIENT,
     DOMAIN,
@@ -117,6 +120,15 @@ async def async_setup_entry(
                 WyzeIrrigationSSID(irrigation_service, device),
             ]
         )
+
+    # battery + firmware for DX-family locks
+    for _dev in hass.data[DOMAIN][config_entry.entry_id].get("iot3_devices", []):
+        _coord = hass.data[DOMAIN][config_entry.entry_id].get("coordinators", {}).get(
+            _dev.mac
+        )
+        if _coord is not None:
+            sensors.append(WyzeIot3BatterySensor(_coord))
+            sensors.append(WyzeIot3FirmwareSensor(_coord))
 
     async_add_entities(sensors, True)
 
@@ -769,3 +781,66 @@ class WyzeAirPurifierHourlyMaxAQISensor(WyzeAirPurifierAirQualitySensor):
         if offset is not None:
             value += offset
         return value.isoformat()
+
+
+class _WyzeIot3SensorBase(CoordinatorEntity, SensorEntity):
+    """Shared plumbing for the DX-family lock sensors."""
+
+    _attr_attribution = ATTRIBUTION
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._device = coordinator.device
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device.mac)},
+            "name": self._device.nickname,
+            "manufacturer": "WyzeLabs",
+            "model": self._device.product_model,
+        }
+
+    @property
+    def available(self):
+        if self.coordinator.data is None:
+            return False
+        return bool(self.coordinator.data.get("online", False))
+
+
+class WyzeIot3BatterySensor(_WyzeIot3SensorBase):
+    """Battery level of a DX-family lock."""
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def name(self):
+        return f"{self._device.nickname} Battery"
+
+    @property
+    def unique_id(self):
+        return f"{self._device.mac}-battery"
+
+    @property
+    def native_value(self):
+        return (self.coordinator.data or {}).get("battery_level")
+
+
+class WyzeIot3FirmwareSensor(_WyzeIot3SensorBase):
+    """Firmware version of a DX-family lock."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def name(self):
+        return f"{self._device.nickname} Firmware"
+
+    @property
+    def unique_id(self):
+        return f"{self._device.mac}-firmware"
+
+    @property
+    def native_value(self):
+        return (self.coordinator.data or {}).get("firmware_ver")


### PR DESCRIPTION
This picks up #809 by @zrikzlok, which was closed for inactivity. The protocol work and most of the code here is theirs. I have put it on current master, worked through the three review comments, and tested it on hardware.

Should close #734, and covers what #839 was asking for.

## What it does

The Lock Bolt v2 (`DX_LB2`) and the Palm Lock (`DX_PVLOC`) report `product_type: "Common"`, so `lock_service.get_locks()` never returns them and they do not show up in Home Assistant at all. They are not Bluetooth devices either, so the Lock Bolt v1 coordinator does not apply to them. Wyze serves them from a separate cloud API under `/app/v4/iot3/` with a signed request body.

This adds an IoT3 client and a per-device coordinator, finds DX devices by `product_model` in the full device list, and creates a `lock` entity plus battery and firmware sensors for each one.

## The review comments on #809

**Coordinators never got an initial refresh.** They are refreshed now before the platforms are forwarded, so the entities come up with data instead of sitting unavailable for the first interval.

I used `async_refresh()` rather than `async_config_entry_first_refresh()`. The latter raises `ConfigEntryNotReady`, which would take the entire config entry down, every camera and bulb and plug on the account, if the lock API happened to be unhappy at startup. For an optional device type that trade seemed wrong to me, especially on a large account. A failed first poll logs a warning and the coordinator retries on its normal interval. Say the word if you would rather have the hard failure and I will change it.

**A failed lock/unlock only logged.** `lock_unlock()` raises `HomeAssistantError` now, both when the request itself fails and when the API comes back with a code other than `1`. So a service call fails visibly instead of reporting success while the bolt never moved. Either way the in-progress flag is cleared and a resync is requested.

**The token was read straight out of `config_entry.data`.** The service holds the `Wyzeapy` client now and refreshes through the auth layer before every request, so it keeps working once the cached token ages out.

One note on that last one. I reach the auth layer through `client._auth_lib`, which is private. It was the only route I could find. If you would rather wyzeapy exposed something public for it, I am happy to open a PR over there and switch this to use it.

## Two changes of my own

**The model comes from `product_model`.** The original parsed it out of the MAC string. Using the device's own `product_model` is one less assumption about how MACs are formatted.

**The entity reflects the command straight away.** Without this the lock kept its old state until the next scheduled poll, about 30 seconds on mine, with no in-progress indication in between. On a successful command the coordinator now writes the commanded value into its data. The poll that follows reconciles with the device, so a bolt that jams or does not fully extend still corrects itself rather than sitting there wrong.

## Testing

Home Assistant 2026.9.0, on a Palm Lock and a Lock Bolt v2:

- Both appear with the right lock state, battery level and firmware, plus the door-open attribute on the Palm Lock.
- Lock and unlock both work. I stood at each door and listened, and each lock ended up back in the state it started in.
- State updates in about 0.1s now instead of ~30s, and the poll afterwards agrees with it.
- A lock that is offline reports `unavailable` instead of looking controllable.
- Nothing new in the log from the integration.

What I have not been able to exercise is the path where Wyze rejects a command outright, so the raise in `lock_unlock` is reasoned rather than tested.